### PR TITLE
Implement core modules and tests

### DIFF
--- a/content_analyzer/config/exclusions_config.yaml
+++ b/content_analyzer/config/exclusions_config.yaml
@@ -1,0 +1,28 @@
+exclusions:
+  extensions:
+    blocked: [".tmp", ".log", ".bak", ".cache"]
+    low_priority: [".txt", ".ini", ".cfg"]
+    high_priority: [".pdf", ".docx", ".doc", ".xlsx"]
+
+  file_size:
+    min_bytes: 100
+    max_bytes: 104857600
+
+  file_attributes:
+    skip_system: true
+    skip_hidden: false
+
+  paths:
+    excluded_patterns:
+      - "*/temp/*"
+      - "*/cache/*"
+      - "*/.git/*"
+    priority_patterns:
+      - "*/documents/*"
+      - "*/contracts/*"
+
+scoring:
+  size_weight: 30
+  type_weight: 40
+  age_weight: 20
+  special_weight: 10

--- a/content_analyzer/config/prompts_config.yaml
+++ b/content_analyzer/config/prompts_config.yaml
@@ -1,0 +1,39 @@
+templates:
+  comprehensive:
+    system_prompt: |
+      Tu es un expert en analyse de documents pour entreprise.
+      Analyse ce fichier et retourne UNIQUEMENT un JSON structuré.
+    user_template: |
+      Fichier: {{ file_name }}
+      Taille: {{ file_size_readable }}
+      Propriétaire: {{ owner }}
+      Dernière modification: {{ last_modified }}
+
+      Analyse selon ces domaines:
+      1. Sécurité: Classification C0-C3
+      2. RGPD: Données personnelles détectées
+      3. Finance: Documents financiers
+      4. Légal: Contrats et documents juridiques
+
+      Format de réponse OBLIGATOIRE:
+      {
+        "security": {"classification": "C0|C1|C2|C3", "confidence": 85},
+        "rgpd": {"risk_level": "none|low|medium|high", "data_types": []},
+        "finance": {"document_type": "none|invoice|contract|budget", "amounts": []},
+        "legal": {"contract_type": "none|employment|lease|sale", "parties": []}
+      }
+
+  security_focused:
+    system_prompt: |
+      Tu es un expert cybersécurité. Classifie ce document selon le niveau de confidentialité.
+    user_template: |
+      Document: {{ file_name }}
+      Métadonnées: {{ metadata_summary }}
+
+      Classification requise:
+      - C0 (Public): Information sans restriction
+      - C1 (Interne): Usage interne entreprise
+      - C2 (Confidentiel): Accès restreint autorisé 
+      - C3 (Secret): Accès très restreint
+
+      Réponse JSON: {"classification": "C0|C1|C2|C3", "justification": "..."}

--- a/content_analyzer/modules/__init__.py
+++ b/content_analyzer/modules/__init__.py
@@ -1,6 +1,17 @@
 """Modules du Content Analyzer."""
 
 from .csv_parser import CSVParser
+from .api_client import APIClient
+from .cache_manager import CacheManager
+from .file_filter import FileFilter
+from .db_manager import DBManager
+from .prompt_manager import PromptManager
 
-__all__ = ["CSVParser"]
-
+__all__ = [
+    "CSVParser",
+    "APIClient",
+    "CacheManager",
+    "FileFilter",
+    "DBManager",
+    "PromptManager",
+]

--- a/content_analyzer/modules/api_client.py
+++ b/content_analyzer/modules/api_client.py
@@ -1,0 +1,73 @@
+import logging
+import time
+from typing import Any, Dict
+
+import requests
+from tenacity import retry, stop_after_attempt, wait_exponential
+from circuitbreaker import circuit
+
+logger = logging.getLogger(__name__)
+
+
+class APIClient:
+    """Client pour communiquer avec l'API-DOC-IA."""
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        self.url = config["api_config"]["url"].rstrip("/")
+        self.token = config["api_config"].get("token")
+        self.timeout = config["api_config"].get("timeout_seconds", 300)
+        self.session = requests.Session()
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=4, max=10))
+    @circuit(failure_threshold=5, recovery_timeout=30)
+    def analyze_file(self, file_path: str, prompt: str) -> Dict[str, Any]:
+        """Analyse un fichier via l'API."""
+        logger.info("Upload %s", file_path)
+        task_id = self._upload_file(file_path, prompt)
+        logger.debug("Task id obtenu: %s", task_id)
+        result = self._poll_result(task_id, timeout=self.timeout)
+        result["task_id"] = task_id
+        return result
+
+    def _upload_file(self, file_path: str, prompt: str) -> str:
+        data = {"prompt": prompt}
+        with open(file_path, "rb") as fh:
+            files = {"file": fh}
+            resp = self.session.post(
+                f"{self.url}/api/v2/process",
+                headers=self._headers(),
+                files=files,
+                data=data,
+                timeout=self.timeout,
+            )
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload.get("task_id")
+
+    def _poll_result(self, task_id: str, timeout: int = 300) -> Dict[str, Any]:
+        start = time.time()
+        while True:
+            if time.time() - start > timeout:
+                return {"status": "failed", "error": "timeout"}
+            resp = self.session.get(
+                f"{self.url}/api/v2/status/{task_id}",
+                headers=self._headers(),
+                timeout=10,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            status = payload.get("status")
+            if status in {"completed", "failed"}:
+                return payload
+            time.sleep(2)
+
+    def health_check(self) -> bool:
+        try:
+            resp = self.session.get(f"{self.url}/api/v2/health", timeout=5)
+            return resp.status_code == 200
+        except requests.RequestException as exc:
+            logger.warning("Health check failed: %s", exc)
+            return False

--- a/content_analyzer/modules/cache_manager.py
+++ b/content_analyzer/modules/cache_manager.py
@@ -1,0 +1,128 @@
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class CacheManager:
+    """Cache SQLite intelligent basé sur FastHash."""
+
+    def __init__(self, db_path: Path, ttl_hours: int = 168) -> None:
+        self.db_path = db_path
+        self.ttl_hours = ttl_hours
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cache_prompts (
+                cache_key TEXT PRIMARY KEY,
+                prompt_hash TEXT NOT NULL,
+                response_content TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                hits_count INTEGER DEFAULT 1,
+                ttl_expiry TIMESTAMP,
+                file_size INTEGER
+            )
+            """
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ttl_expiry ON cache_prompts(ttl_expiry)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hits_count ON cache_prompts(hits_count DESC)"
+        )
+        conn.commit()
+        conn.close()
+
+    def get_cached_result(
+        self, fast_hash: str, prompt_hash: str
+    ) -> Optional[Dict[str, Any]]:
+        key = f"{fast_hash}_{prompt_hash}"
+        conn = self._connect()
+        cursor = conn.cursor()
+        row = cursor.execute(
+            "SELECT response_content, hits_count, ttl_expiry FROM cache_prompts WHERE cache_key = ?",
+            (key,),
+        ).fetchone()
+        result = None
+        if row:
+            expiry = row[2]
+            if expiry and time.time() > float(expiry):
+                conn.execute("DELETE FROM cache_prompts WHERE cache_key = ?", (key,))
+                conn.commit()
+            else:
+                conn.execute(
+                    "UPDATE cache_prompts SET hits_count = hits_count + 1 WHERE cache_key = ?",
+                    (key,),
+                )
+                conn.commit()
+                result = json.loads(row[0])
+        conn.close()
+        return result
+
+    def store_result(
+        self, fast_hash: str, prompt_hash: str, result: Dict[str, Any]
+    ) -> None:
+        key = f"{fast_hash}_{prompt_hash}"
+        expiry = time.time() + self.ttl_hours * 3600
+        conn = self._connect()
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO cache_prompts (
+                cache_key, prompt_hash, response_content, ttl_expiry, file_size
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                key,
+                prompt_hash,
+                json.dumps(result),
+                expiry,
+                result.get("file_size"),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def cleanup_expired(self) -> int:
+        now = time.time()
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM cache_prompts WHERE ttl_expiry IS NOT NULL AND ttl_expiry <= ?",
+            (now,),
+        )
+        deleted = cursor.rowcount
+        conn.commit()
+        conn.close()
+        return deleted
+
+    def get_stats(self) -> Dict[str, Any]:
+        conn = self._connect()
+        cursor = conn.cursor()
+        total = cursor.execute("SELECT COUNT(*) FROM cache_prompts").fetchone()[0]
+        hits = (
+            cursor.execute("SELECT SUM(hits_count) FROM cache_prompts").fetchone()[0]
+            or 0
+        )
+        oldest_row = cursor.execute(
+            "SELECT MIN(created_at) FROM cache_prompts"
+        ).fetchone()[0]
+        size_bytes = Path(self.db_path).stat().st_size
+        conn.close()
+        hit_rate = 0.0
+        if hits and total:
+            hit_rate = (hits - total) / hits * 100
+        return {
+            "total_entries": total,
+            "hit_rate": round(hit_rate, 2),
+            "cache_size_mb": round(size_bytes / (1024 * 1024), 2),
+            "oldest_entry": oldest_row,
+            "cleanup_needed": total > 10000,
+        }

--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -1,0 +1,145 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class DBManager:
+    """Gestionnaire SQLite pour stocker les analyses."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reponses_llm (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                fichier_id INTEGER REFERENCES fichiers(id),
+                task_id TEXT NOT NULL,
+                security_analysis TEXT,
+                rgpd_analysis TEXT,
+                finance_analysis TEXT,
+                legal_analysis TEXT,
+                confidence_global INTEGER,
+                processing_time_ms INTEGER,
+                api_tokens_used INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_fichier_id ON reponses_llm(fichier_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_task_id ON reponses_llm(task_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_confidence ON reponses_llm(confidence_global DESC)"
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metriques_performance (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                files_processed INTEGER,
+                avg_processing_time REAL,
+                cache_hit_rate REAL,
+                api_success_rate REAL,
+                memory_usage_mb INTEGER
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def store_analysis_result(
+        self, file_id: int, task_id: str, llm_response: Dict[str, Any]
+    ) -> None:
+        conn = self._connect()
+        conn.execute(
+            """
+            INSERT INTO reponses_llm (
+                fichier_id, task_id, security_analysis, rgpd_analysis,
+                finance_analysis, legal_analysis, confidence_global,
+                processing_time_ms, api_tokens_used
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                file_id,
+                task_id,
+                json.dumps(llm_response.get("security")),
+                json.dumps(llm_response.get("rgpd")),
+                json.dumps(llm_response.get("finance")),
+                json.dumps(llm_response.get("legal")),
+                llm_response.get("confidence", 0),
+                llm_response.get("processing_time_ms", 0),
+                llm_response.get("api_tokens_used", 0),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def get_pending_files(
+        self, limit: int = 100, priority_threshold: int = 0
+    ) -> List[Dict[str, Any]]:
+        conn = self._connect()
+        cursor = conn.cursor()
+        rows = cursor.execute(
+            """
+            SELECT * FROM fichiers
+            WHERE status = 'pending' AND priority_score >= ?
+            ORDER BY priority_score DESC
+            LIMIT ?
+            """,
+            (priority_threshold, limit),
+        ).fetchall()
+        columns = [desc[0] for desc in cursor.description]
+        conn.close()
+        return [dict(zip(columns, row)) for row in rows]
+
+    def update_file_status(
+        self, file_id: int, status: str, error_message: Optional[str] = None
+    ) -> None:
+        conn = self._connect()
+        conn.execute(
+            "UPDATE fichiers SET status = ?, exclusion_reason = ? WHERE id = ?",
+            (status, error_message, file_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def get_processing_stats(self) -> Dict[str, Any]:
+        conn = self._connect()
+        cursor = conn.cursor()
+        total = cursor.execute("SELECT COUNT(*) FROM fichiers").fetchone()[0]
+        pending = cursor.execute(
+            "SELECT COUNT(*) FROM fichiers WHERE status = 'pending'"
+        ).fetchone()[0]
+        processing = cursor.execute(
+            "SELECT COUNT(*) FROM fichiers WHERE status = 'processing'"
+        ).fetchone()[0]
+        completed = cursor.execute(
+            "SELECT COUNT(*) FROM fichiers WHERE status = 'completed'"
+        ).fetchone()[0]
+        errors = cursor.execute(
+            "SELECT COUNT(*) FROM fichiers WHERE status = 'error'"
+        ).fetchone()[0]
+        avg_time_row = cursor.execute(
+            "SELECT AVG(processing_time_ms) FROM reponses_llm"
+        ).fetchone()[0]
+        conn.close()
+        return {
+            "total_files": total,
+            "pending": pending,
+            "processing": processing,
+            "completed": completed,
+            "errors": errors,
+            "avg_processing_time": float(avg_time_row or 0.0),
+        }

--- a/content_analyzer/modules/file_filter.py
+++ b/content_analyzer/modules/file_filter.py
@@ -1,0 +1,83 @@
+import fnmatch
+import yaml
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+class FileFilter:
+    def __init__(self, exclusions_config_path: Path) -> None:
+        with open(exclusions_config_path, "r", encoding="utf-8") as f:
+            self.cfg = yaml.safe_load(f)
+
+    def should_process_file(self, file_row: Dict[str, Any]) -> Tuple[bool, str]:
+        ext = str(file_row.get("extension", "")).lower()
+        size = int(file_row.get("file_size", 0))
+        path = file_row.get("path", "")
+        attrs = file_row.get("file_attributes", "")
+        rules = self.cfg["exclusions"]
+
+        if ext in rules["extensions"].get("blocked", []):
+            return False, "blocked_extension"
+        if size < rules["file_size"].get("min_bytes", 0):
+            return False, "too_small"
+        if size > rules["file_size"].get("max_bytes", 1 << 30):
+            return False, "too_large"
+        if rules["file_attributes"].get("skip_system") and "system" in attrs.lower():
+            return False, "system_file"
+        if rules["file_attributes"].get("skip_hidden") and "hidden" in attrs.lower():
+            return False, "hidden_file"
+        for pattern in rules["paths"].get("excluded_patterns", []):
+            if fnmatch.fnmatch(path, pattern):
+                return False, "excluded_path"
+        return True, "ok"
+
+    def calculate_priority_score(self, file_row: Dict[str, Any]) -> int:
+        ext = str(file_row.get("extension", "")).lower()
+        size = int(file_row.get("file_size", 0))
+        age = file_row.get("last_modified", "0")
+        attrs = file_row.get("file_attributes", "")
+
+        score_cfg = self.cfg["scoring"]
+        weight_size = score_cfg.get("size_weight", 30)
+        weight_type = score_cfg.get("type_weight", 40)
+        weight_age = score_cfg.get("age_weight", 20)
+        weight_special = score_cfg.get("special_weight", 10)
+
+        max_size = self.cfg["exclusions"]["file_size"].get("max_bytes", 1)
+        size_ratio = min(size / max_size, 1.0)
+        size_score = size_ratio * weight_size
+
+        type_score = 0
+        if ext in self.cfg["exclusions"]["extensions"].get("high_priority", []):
+            type_score = weight_type
+        elif ext in self.cfg["exclusions"]["extensions"].get("low_priority", []):
+            type_score = weight_type * 0.3
+        else:
+            type_score = weight_type * 0.6
+
+        age_score = weight_age  # simplification
+
+        special = 0
+        if "hidden" in attrs.lower():
+            special += weight_special / 2
+        if "system" in attrs.lower():
+            special += weight_special / 2
+
+        total = size_score + type_score + age_score + special
+        return int(min(total, 100))
+
+    def get_special_flags(self, file_row: Dict[str, Any]) -> List[str]:
+        flags: List[str] = []
+        attrs = file_row.get("file_attributes", "")
+        if "hidden" in attrs.lower():
+            flags.append("hidden_file")
+        if "system" in attrs.lower():
+            flags.append("system_file")
+        if file_row.get("file_signature") and file_row.get("extension"):
+            if (
+                not file_row["file_signature"]
+                .lower()
+                .endswith(file_row["extension"].lower())
+            ):
+                flags.append("signature_mismatch")
+        return flags

--- a/content_analyzer/modules/prompt_manager.py
+++ b/content_analyzer/modules/prompt_manager.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import jinja2
+import yaml
+
+
+class PromptManager:
+    """Gestionnaire de templates Jinja2 pour la génération de prompts."""
+
+    def __init__(self, prompts_config_path: Path) -> None:
+        with open(prompts_config_path, "r", encoding="utf-8") as f:
+            self.cfg = yaml.safe_load(f)
+        self.env = jinja2.Environment(autoescape=False)
+
+    def build_analysis_prompt(
+        self, file_metadata: Dict[str, Any], analysis_type: str = "comprehensive"
+    ) -> str:
+        tpl_cfg = self.cfg["templates"].get(analysis_type)
+        if not tpl_cfg:
+            raise ValueError(f"Unknown template: {analysis_type}")
+        user_tpl = self.env.from_string(tpl_cfg["user_template"])
+        rendered = user_tpl.render(**file_metadata)
+        system_prompt = tpl_cfg.get("system_prompt", "")
+        return f"{system_prompt}\n{rendered}"
+
+    def get_available_templates(self) -> List[str]:
+        return list(self.cfg.get("templates", {}).keys())
+
+    def validate_template(self, template_name: str) -> Tuple[bool, str]:
+        tpl_cfg = self.cfg["templates"].get(template_name)
+        if not tpl_cfg:
+            return False, "template_not_found"
+        try:
+            self.env.parse(tpl_cfg["user_template"])
+            return True, "ok"
+        except jinja2.TemplateSyntaxError as exc:
+            return False, str(exc)

--- a/content_analyzer/tests/test_api_client.py
+++ b/content_analyzer/tests/test_api_client.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from unittest import mock
+import pytest
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.api_client import APIClient
+from circuitbreaker import CircuitBreakerError, CircuitBreakerMonitor
+from tenacity import RetryError
+
+CONFIG = {
+    "api_config": {"url": "http://localhost:8080", "token": "t", "timeout_seconds": 5},
+}
+
+
+def test_health_check():
+    client = APIClient(CONFIG)
+    CircuitBreakerMonitor.get("APIClient.analyze_file").reset()
+    with mock.patch.object(client.session, "get") as mget:
+        mget.return_value.status_code = 200
+        assert client.health_check() is True
+
+
+def test_analyze_file_success(tmp_path):
+    client = APIClient(CONFIG)
+    CircuitBreakerMonitor.get("APIClient.analyze_file").reset()
+    file_path = tmp_path / "f.txt"
+    file_path.write_text("data")
+    with (
+        mock.patch.object(client.session, "post") as mpost,
+        mock.patch.object(client.session, "get") as mget,
+    ):
+        mpost.return_value.json.return_value = {"task_id": "1"}
+        mpost.return_value.raise_for_status.return_value = None
+        mget.return_value.json.return_value = {
+            "status": "completed",
+            "result": {"ok": True},
+        }
+        mget.return_value.raise_for_status.return_value = None
+        result = client.analyze_file(str(file_path), "prompt")
+    assert result["status"] == "completed"
+
+
+def test_analyze_file_with_retry(tmp_path):
+    client = APIClient(CONFIG)
+    CircuitBreakerMonitor.get("APIClient.analyze_file").reset()
+    file_path = tmp_path / "f.txt"
+    file_path.write_text("data")
+    with (
+        mock.patch.object(client.session, "post") as mpost,
+        mock.patch.object(client.session, "get") as mget,
+    ):
+        resp = mock.Mock()
+        resp.json.return_value = {"task_id": "2"}
+        resp.raise_for_status.return_value = None
+        mpost.side_effect = [Exception("fail"), resp]
+        mget.return_value.json.return_value = {"status": "completed", "result": {}}
+        mget.return_value.raise_for_status.return_value = None
+        result = client.analyze_file(str(file_path), "prompt")
+    assert result["task_id"] == "2"
+
+
+def test_circuit_breaker_activation(tmp_path):
+    client = APIClient(CONFIG)
+    CircuitBreakerMonitor.get("APIClient.analyze_file").reset()
+    file_path = tmp_path / "f.txt"
+    file_path.write_text("data")
+    with mock.patch.object(client.session, "post", side_effect=Exception("boom")):
+        for _ in range(5):
+            try:
+                client.analyze_file(str(file_path), "p")
+            except Exception:
+                pass
+        with pytest.raises(RetryError):
+            client.analyze_file(str(file_path), "p")
+
+
+def test_timeout_handling(tmp_path):
+    client = APIClient(CONFIG)
+    CircuitBreakerMonitor.get("APIClient.analyze_file").reset()
+    file_path = tmp_path / "f.txt"
+    file_path.write_text("data")
+    with (
+        mock.patch.object(client.session, "post") as mpost,
+        mock.patch.object(client.session, "get") as mget,
+    ):
+        mpost.return_value.json.return_value = {"task_id": "3"}
+        mpost.return_value.raise_for_status.return_value = None
+        mget.return_value.json.return_value = {"status": "processing"}
+        mget.return_value.raise_for_status.return_value = None
+        result = client.analyze_file(str(file_path), "prompt")
+    assert result["status"] == "failed"

--- a/content_analyzer/tests/test_cache_manager.py
+++ b/content_analyzer/tests/test_cache_manager.py
@@ -1,0 +1,48 @@
+import json
+import sqlite3
+import time
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.cache_manager import CacheManager
+
+
+def test_store_and_retrieve(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("hash1", "ph1", {"result": "ok"})
+    result = cache.get_cached_result("hash1", "ph1")
+    assert result == {"result": "ok"}
+
+
+def test_cache_expiration(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=0)
+    cache.store_result("h", "p", {"a": 1})
+    expired = cache.get_cached_result("h", "p")
+    assert expired is None
+
+
+def test_hit_rate_calculation(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("h", "p", {"a": 1})
+    cache.get_cached_result("h", "p")
+    cache.get_cached_result("h", "p")
+    stats = cache.get_stats()
+    assert stats["total_entries"] == 1
+    assert stats["hit_rate"] > 0
+
+
+def test_cleanup_expired(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("h1", "p", {"a": 1})
+    conn = sqlite3.connect(db_file)
+    conn.execute("UPDATE cache_prompts SET ttl_expiry = ?", (time.time() - 10,))
+    conn.commit()
+    conn.close()
+    deleted = cache.cleanup_expired()
+    assert deleted == 1

--- a/content_analyzer/tests/test_db_manager.py
+++ b/content_analyzer/tests/test_db_manager.py
@@ -1,0 +1,88 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.db_manager import DBManager
+
+
+def setup_db(path: Path) -> DBManager:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE fichiers (id INTEGER PRIMARY KEY, priority_score INTEGER, status TEXT, exclusion_reason TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    return DBManager(path)
+
+
+def test_store_analysis_result(tmp_path):
+    db_file = tmp_path / "test.db"
+    db = setup_db(db_file)
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        "INSERT INTO fichiers (id, priority_score, status) VALUES (1, 10, 'pending')"
+    )
+    conn.commit()
+    conn.close()
+    db.store_analysis_result(
+        1, "t1", {"security": {}, "rgpd": {}, "finance": {}, "legal": {}}
+    )
+    conn = sqlite3.connect(db_file)
+    count = conn.execute("SELECT COUNT(*) FROM reponses_llm").fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_get_pending_files(tmp_path):
+    db_file = tmp_path / "test.db"
+    db = setup_db(db_file)
+    conn = sqlite3.connect(db_file)
+    conn.executemany(
+        "INSERT INTO fichiers (id, priority_score, status) VALUES (?, ?, 'pending')",
+        [(1, 50), (2, 20)],
+    )
+    conn.commit()
+    conn.close()
+    files = db.get_pending_files(limit=2, priority_threshold=10)
+    assert len(files) == 2
+
+
+def test_processing_stats(tmp_path):
+    db_file = tmp_path / "test.db"
+    db = setup_db(db_file)
+    conn = sqlite3.connect(db_file)
+    conn.executemany(
+        "INSERT INTO fichiers (id, priority_score, status) VALUES (?, ?, ?)",
+        [(1, 0, "pending"), (2, 0, "completed"), (3, 0, "error")],
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS reponses_llm (task_id TEXT, processing_time_ms INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO reponses_llm (task_id, processing_time_ms) VALUES ('t', 100)"
+    )
+    conn.commit()
+    conn.close()
+    stats = db.get_processing_stats()
+    assert stats["total_files"] == 3
+    assert stats["completed"] == 1
+
+
+def test_concurrent_access(tmp_path):
+    db_file = tmp_path / "test.db"
+    db1 = setup_db(db_file)
+    db2 = DBManager(db_file)
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        "INSERT INTO fichiers (id, priority_score, status, exclusion_reason) VALUES (1, 0, 'pending', '')"
+    )
+    conn.commit()
+    conn.close()
+    db1.update_file_status(1, "processing")
+    db2.update_file_status(1, "completed")
+    conn = sqlite3.connect(db_file)
+    status = conn.execute("SELECT status FROM fichiers WHERE id=1").fetchone()[0]
+    conn.close()
+    assert status == "completed"

--- a/content_analyzer/tests/test_file_filter.py
+++ b/content_analyzer/tests/test_file_filter.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.file_filter import FileFilter
+
+CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "content_analyzer"
+    / "config"
+    / "exclusions_config.yaml"
+)
+
+
+def sample_row(**kwargs):
+    base = {
+        "path": "/share/documents/report.pdf",
+        "extension": ".pdf",
+        "file_size": 2000,
+        "file_attributes": "",
+        "last_modified": "2024-01-01",
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_should_process_valid_file():
+    ffilter = FileFilter(CONFIG)
+    ok, reason = ffilter.should_process_file(sample_row())
+    assert ok and reason == "ok"
+
+
+def test_exclusion_rules():
+    ffilter = FileFilter(CONFIG)
+    ok, reason = ffilter.should_process_file(sample_row(extension=".tmp"))
+    assert not ok and reason == "blocked_extension"
+
+
+def test_priority_scoring():
+    ffilter = FileFilter(CONFIG)
+    score = ffilter.calculate_priority_score(sample_row())
+    assert 0 <= score <= 100
+
+
+def test_special_flags_detection():
+    ffilter = FileFilter(CONFIG)
+    flags = ffilter.get_special_flags(sample_row(file_attributes="hidden system"))
+    assert "hidden_file" in flags and "system_file" in flags

--- a/content_analyzer/tests/test_prompt_manager.py
+++ b/content_analyzer/tests/test_prompt_manager.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.prompt_manager import PromptManager
+
+CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "content_analyzer"
+    / "config"
+    / "prompts_config.yaml"
+)
+
+
+def test_build_comprehensive_prompt():
+    pm = PromptManager(CONFIG)
+    prompt = pm.build_analysis_prompt(
+        {
+            "file_name": "test.txt",
+            "file_size_readable": "1KB",
+            "owner": "me",
+            "last_modified": "today",
+        }
+    )
+    assert "test.txt" in prompt
+
+
+def test_template_validation():
+    pm = PromptManager(CONFIG)
+    ok, reason = pm.validate_template("comprehensive")
+    assert ok
+
+
+def test_metadata_injection():
+    pm = PromptManager(CONFIG)
+    prompt = pm.build_analysis_prompt(
+        {
+            "file_name": "doc.pdf",
+            "file_size_readable": "2KB",
+            "owner": "me",
+            "last_modified": "now",
+        },
+        analysis_type="security_focused",
+    )
+    assert "doc.pdf" in prompt
+
+
+def test_security_focused_prompt():
+    pm = PromptManager(CONFIG)
+    prompt = pm.build_analysis_prompt(
+        {"file_name": "a.pdf", "metadata_summary": "meta"},
+        analysis_type="security_focused",
+    )
+    assert "Classification" in prompt


### PR DESCRIPTION
## Summary
- implement API client with retry & circuit breaker
- add SQLite cache manager
- create file filter logic with scoring
- manage analysis database
- handle prompt templates
- include configs for exclusions and prompts
- add unit tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530f3b8c348320bb1c7597c93b165d