### PR TITLE
Fix GUI critical issues

### DIFF
--- a/content_analyzer/config/analyzer_config.yaml
+++ b/content_analyzer/config/analyzer_config.yaml
@@ -11,6 +11,13 @@ api_config:
   timeout_seconds: 300
   batch_size: 100
 
+brique2_analyzer:
+  api_url: "http://localhost:8080"
+  api_token: "sk-d88e3244ae2e4b64a5256c6f4946155a"
+  max_tokens: 32000
+  timeout_seconds: 300
+  batch_size: 100
+
 # Configuration tenacity retry
 retry_config:
   max_attempts: 3
@@ -82,8 +89,23 @@ scoring:
 
 templates:
   comprehensive:
-    system_prompt: "Tu es un expert en analyse de documents pour entreprise."
-    user_template: "Fichier: {{ file_name }}\nAnalyse ce document."
+    system_prompt: |
+      Tu es un expert en analyse de documents pour entreprise.
+      Analyse ce fichier et retourne UNIQUEMENT un JSON structuré.
+
+    user_template: |
+      Fichier: {{ file_name }}
+      Taille: {{ file_size_readable }}
+      Propriétaire: {{ owner }}
+      Dernière modification: {{ last_modified }}
+
+      Analyse selon ces domaines et retourne UNIQUEMENT ce JSON :
+      {
+        "security": {"classification": "C0|C1|C2|C3", "confidence": 85, "justification": "Raison du classement"},
+        "rgpd": {"risk_level": "none|low|medium|high", "data_types": ["email", "phone"], "confidence": 90},
+        "finance": {"document_type": "none|invoice|contract|budget", "amounts": [{"value": "1500€", "context": "facture"}], "confidence": 75},
+        "legal": {"contract_type": "none|employment|lease|sale", "parties": ["entreprise", "client"], "confidence": 80}
+      }
   security_focused:
     system_prompt: "Expert sécurité"
     user_template: "Analyse de sécurité pour {{ file_name }}\nClassification :"

--- a/doc/gui_corrections_notes.md
+++ b/doc/gui_corrections_notes.md
@@ -1,0 +1,18 @@
+# GUI Corrections Notes
+
+This file summarises the fixes applied to solve the four blocking issues in the GUI.
+
+## Main Changes
+- added verification of `fichiers` table existence in the results viewer to avoid
+  `no such table` errors.
+- the API configuration panel now exposes a field to edit the API token and the
+  token is saved and loaded from `analyzer_config.yaml`.
+- prompts are now generated through `PromptManager` and the YAML templates have
+  been updated with a structured JSON instruction.
+- analysis results are parsed and formatted for display using the new
+  `display_analysis_result` helper.
+
+## Questions
+1. Should the `brique2_analyzer` section fully replace `api_config` or stay as a
+   compatibility alias?
+2. Is additional formatting desired for other windows such as exports?


### PR DESCRIPTION
## Summary
- add API token field in the configuration panel
- read/write token when loading or saving API settings
- verify SQLite table before refreshing results
- display formatted analysis results instead of raw JSON
- update prompt templates with structured JSON instructions
- document changes in `doc/gui_corrections_notes.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68547520b3788320a50b1589cedbf2ae