### PR TITLE
Fix GUI table check and add API token

### DIFF
--- a/content_analyzer/config/analyzer_config.yaml
+++ b/content_analyzer/config/analyzer_config.yaml
@@ -82,8 +82,23 @@ scoring:
 
 templates:
   comprehensive:
-    system_prompt: "Tu es un expert en analyse de documents pour entreprise."
-    user_template: "Fichier: {{ file_name }}\nAnalyse ce document."
+    system_prompt: |
+      Tu es un expert en analyse de documents pour entreprise.
+      Analyse ce fichier et retourne UNIQUEMENT un JSON structuré.
+
+    user_template: |
+      Fichier: {{ file_name }}
+      Taille: {{ file_size_readable }}
+      Propriétaire: {{ owner }}
+      Dernière modification: {{ last_modified }}
+
+      Analyse selon ces domaines et retourne UNIQUEMENT ce JSON :
+      {
+        "security": {"classification": "C0|C1|C2|C3", "confidence": 85, "justification": "Raison du classement"},
+        "rgpd": {"risk_level": "none|low|medium|high", "data_types": ["email", "phone"], "confidence": 90},
+        "finance": {"document_type": "none|invoice|contract|budget", "amounts": [{"value": "1500€", "context": "facture"}], "confidence": 75},
+        "legal": {"contract_type": "none|employment|lease|sale", "parties": ["entreprise", "client"], "confidence": 80}
+      }
   security_focused:
     system_prompt: "Expert sécurité"
     user_template: "Analyse de sécurité pour {{ file_name }}\nClassification :"

--- a/doc/corrections_update.md
+++ b/doc/corrections_update.md
@@ -1,0 +1,14 @@
+# GUI Corrections Summary
+
+This document lists the main fixes and questions applied by Codex.
+
+## Changes
+- Added verification of the `fichiers` table in `refresh_results_table`.
+- Implemented token field in API configuration panel with save/load support.
+- Updated `analyze_single_file` to build structured prompts using `PromptManager`.
+- Added formatted display of analysis results instead of raw JSON.
+- Updated comprehensive prompt template in `analyzer_config.yaml`.
+
+## Questions
+- Should additional templates be added for other analysis modes?
+- Are there plans for more granular caching policies?


### PR DESCRIPTION
## Summary
- add API token field and save/load logic
- verify `fichiers` table exists before refreshing results
- parse & display analysis results
- generate structured prompts in `ContentAnalyzer`
- expand YAML template and add doc notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68547f05e11c8320958a6971f21ac32d