### PR TITLE
Add resume support to LLM content analyzer

### DIFF
--- a/content_analyzer/config/analyzer_config.yaml
+++ b/content_analyzer/config/analyzer_config.yaml
@@ -96,10 +96,11 @@ templates:
 
       Analyse ce fichier et retourne UNIQUEMENT ce JSON (rien d'autre) :
       {
-        "security": {"classification": "C0|C1|C2|C3", "confidence": 85, "justification": "Raison du classement"},
-        "rgpd": {"risk_level": "none|low|medium|high", "data_types": ["email", "phone"], "confidence": 90},
-        "finance": {"document_type": "none|invoice|contract|budget", "amounts": [{"value": "1500€", "context": "facture"}], "confidence": 75},
-        "legal": {"contract_type": "none|employment|lease|sale", "parties": ["entreprise", "client"], "confidence": 80}
+        "resume": "Résumé du document en 50 mots maximum décrivant son contenu principal",
+        "security": {"classification": "C0|C1|C2|C3", "confidence": 85, "justification": "..."},
+        "rgpd": {"risk_level": "none|low|medium|high", "data_types": [], "confidence": 90},
+        "finance": {"document_type": "none|invoice|contract|budget", "amounts": [], "confidence": 75},
+        "legal": {"contract_type": "none|employment|lease|sale", "parties": [], "confidence": 80}
       }
   security_focused:
     system_prompt: "Expert sécurité"

--- a/content_analyzer/modules/csv_parser.py
+++ b/content_analyzer/modules/csv_parser.py
@@ -421,6 +421,10 @@ class CSVParser:
             or row_dict.get("CreationTime", ""),
         }
 
+    def transform_metadata(self, row: "pd.Series") -> Dict[str, Any]:
+        """Compatibilité ancienne API utilisant pandas."""
+        return self.transform_metadata_from_dict(row.to_dict())
+
     def parse_csv(
         self,
         csv_file: Path,

--- a/content_analyzer/tests/test_content_analyzer.py
+++ b/content_analyzer/tests/test_content_analyzer.py
@@ -53,18 +53,20 @@ def test_analyze_batch(tmp_path):
     csv_file = create_sample_csv(tmp_path, 3)
     out_db = tmp_path / "out.db"
     analyzer = ContentAnalyzer(CFG)
+    analyzer.csv_parser.validation_strict = False
     analyzer.enable_cache = True
     with mock.patch.object(analyzer.api_client, "analyze_file") as mapi:
         mapi.return_value = {
             "status": "completed",
-            "result": {},
+            "result": {"content": "{}"},
             "task_id": "t1",
         }
         result = analyzer.analyze_batch(csv_file, out_db)
     assert result["status"] == "completed"
     assert result["files_processed"] == 3
     conn = sqlite3.connect(out_db)
-    count = conn.execute("SELECT COUNT(*) FROM fichiers WHERE status='completed'").fetchone()[0]
+    count = conn.execute(
+        "SELECT COUNT(*) FROM fichiers WHERE status='completed'"
+    ).fetchone()[0]
     conn.close()
     assert count == 3
-

--- a/content_analyzer/tests/test_db_manager.py
+++ b/content_analyzer/tests/test_db_manager.py
@@ -27,7 +27,11 @@ def test_store_analysis_result(tmp_path):
     conn.commit()
     conn.close()
     db.store_analysis_result(
-        1, "t1", {"security": {}, "rgpd": {}, "finance": {}, "legal": {}}
+        1,
+        "t1",
+        {"security": {}, "rgpd": {}, "finance": {}, "legal": {}},
+        "",
+        "{}",
     )
     conn = sqlite3.connect(db_file)
     count = conn.execute("SELECT COUNT(*) FROM reponses_llm").fetchone()[0]

--- a/content_analyzer/tests/test_resume.py
+++ b/content_analyzer/tests/test_resume.py
@@ -1,0 +1,68 @@
+import sqlite3
+from pathlib import Path
+import sys
+import tkinter as tk
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.content_analyzer import ContentAnalyzer
+from content_analyzer.modules.db_manager import DBManager
+from gui.main_window import MainWindow
+
+CFG = Path(__file__).resolve().parents[1] / "config" / "analyzer_config.yaml"
+
+
+def test_resume_extraction():
+    analyzer = ContentAnalyzer(CFG)
+    api_res = {
+        "status": "completed",
+        "result": {
+            "content": '{"resume": "court", "security": {"classification": "C1"}}'
+        },
+        "task_id": "1",
+    }
+    parsed = analyzer._parse_api_response(api_res)
+    assert parsed["resume"] == "court"
+
+    api_res["result"]["content"] = '{"security": {"classification": "C0"}}'
+    parsed = analyzer._parse_api_response(api_res)
+    assert parsed["resume"] == ""
+
+    long_text = "word " * 60
+    api_res["result"]["content"] = '{"resume": "' + long_text + '"}'
+    parsed = analyzer._parse_api_response(api_res)
+    assert len(parsed["resume"].split()) <= 50
+
+
+def test_database_migration(tmp_path):
+    db_file = tmp_path / "migr.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute("CREATE TABLE fichiers (id INTEGER PRIMARY KEY)")
+    conn.execute(
+        "CREATE TABLE reponses_llm (id INTEGER PRIMARY KEY, fichier_id INTEGER, task_id TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    db = DBManager(db_file)
+    conn = sqlite3.connect(db_file)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(reponses_llm)").fetchall()]
+    assert "document_resume" in cols and "llm_response_complete" in cols
+    db.store_analysis_result(1, "t1", {"security": {}}, "resume", "{}")
+    row = conn.execute(
+        "SELECT document_resume, llm_response_complete FROM reponses_llm WHERE id=1"
+    ).fetchone()
+    conn.close()
+    assert row == ("resume", "{}")
+
+
+def test_gui_display(monkeypatch):
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("no display")
+    mw = MainWindow(root)
+    text = mw._format_analysis_display({"resume": "short"})
+    root.destroy()
+    assert "short" in text

--- a/gui/utils/analysis_thread.py
+++ b/gui/utils/analysis_thread.py
@@ -58,6 +58,8 @@ class AnalysisThread(threading.Thread):
                         row["id"],
                         single_res.get("task_id", ""),
                         single_res.get("result", {}),
+                        single_res.get("resume", ""),
+                        single_res.get("raw_response", ""),
                     )
                     db_mgr.update_file_status(row["id"], "completed")
                 else:


### PR DESCRIPTION
## Summary
- extend comprehensive prompt with `resume` field
- migrate SQLite schema for document summaries and raw LLM responses
- parse `resume` and raw response in ContentAnalyzer
- store new fields and show them in GUI
- update CSV parser and tests for compatibility
- add new unit tests for resume functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68571b94150c832098146b41f687f5ad