### PR TITLE
Fix GUI bugs for modal grab and processing time

### DIFF
--- a/content_analyzer/content_analyzer.py
+++ b/content_analyzer/content_analyzer.py
@@ -301,10 +301,12 @@ class ContentAnalyzer:
         for row in files:
             res = self.analyze_single_file(row)
             if res.get("status") in {"completed", "cached"}:
+                llm_data = res.get("result", {})
+                llm_data["processing_time_ms"] = res.get("processing_time_ms", 0)
                 self.db_manager.store_analysis_result(
                     row["id"],
                     res.get("task_id", ""),
-                    res.get("result", {}),
+                    llm_data,
                     res.get("resume", ""),
                     res.get("raw_response", ""),
                 )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -134,7 +134,6 @@ No need to run analysis to see your files.
         dialog.title(title)
         dialog.geometry(geometry)
         dialog.transient(parent)
-        dialog.grab_set()
         dialog.lift()
         dialog.focus_set()
         dialog.update_idletasks()
@@ -145,6 +144,7 @@ No need to run analysis to see your files.
             dialog.winfo_height() // 2
         )
         dialog.geometry(f"+{x}+{y}")
+        dialog.after_idle(lambda: dialog.grab_set())
         return dialog
 
     def build_ui(self) -> None:
@@ -1188,10 +1188,12 @@ No need to run analysis to see your files.
             for row in files:
                 res = analyzer.analyze_single_file(row)
                 if res.get("status") in {"completed", "cached"}:
+                    llm_data = res.get("result", {})
+                    llm_data["processing_time_ms"] = res.get("processing_time_ms", 0)
                     db_mgr.store_analysis_result(
                         row["id"],
                         res.get("task_id", ""),
-                        res.get("result", {}),
+                        llm_data,
                         res.get("resume", ""),
                         res.get("raw_response", ""),
                     )
@@ -1232,10 +1234,12 @@ No need to run analysis to see your files.
                 row = dict(zip(columns, r))
                 res = analyzer.analyze_single_file(row)
                 if res.get("status") in {"completed", "cached"}:
+                    llm_data = res.get("result", {})
+                    llm_data["processing_time_ms"] = res.get("processing_time_ms", 0)
                     db_mgr.store_analysis_result(
                         row["id"],
                         res.get("task_id", ""),
-                        res.get("result", {}),
+                        llm_data,
                         res.get("resume", ""),
                         res.get("raw_response", ""),
                     )

--- a/gui/utils/analysis_thread.py
+++ b/gui/utils/analysis_thread.py
@@ -54,10 +54,14 @@ class AnalysisThread(threading.Thread):
                 self.current_file = row.get("path")
                 single_res = analyzer.analyze_single_file(row)
                 if single_res.get("status") in {"completed", "cached"}:
+                    llm_data = single_res.get("result", {})
+                    llm_data["processing_time_ms"] = single_res.get(
+                        "processing_time_ms", 0
+                    )
                     db_mgr.store_analysis_result(
                         row["id"],
                         single_res.get("task_id", ""),
-                        single_res.get("result", {}),
+                        llm_data,
                         single_res.get("resume", ""),
                         single_res.get("raw_response", ""),
                     )


### PR DESCRIPTION
## Summary
- prevent grab failures by calling `grab_set` after idle in `create_dialog_window`
- ensure processing time is stored and displayed by passing `processing_time_ms` to `store_analysis_result`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ed897a9c8320acde3fbde6b9b10e