### PR TITLE
Fix cache storage to include resume and raw response

### DIFF
--- a/content_analyzer/tests/test_cache_complete.py
+++ b/content_analyzer/tests/test_cache_complete.py
@@ -1,0 +1,44 @@
+import sqlite3
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.cache_manager import CacheManager
+
+
+def test_cache_stores_resume_and_raw_response(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("fast", "prompt", {"a": 1}, "short resume", '{"raw": true}')
+    res = cache.get_cached_result("fast", "prompt")
+    assert res["analysis_data"] == {"a": 1}
+    assert res["resume"] == "short resume"
+    assert res["raw_response"] == '{"raw": true}'
+
+
+def test_backward_compatibility_existing_cache(tmp_path):
+    db_file = tmp_path / "cache.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        """
+        CREATE TABLE cache_prompts (
+            cache_key TEXT PRIMARY KEY,
+            prompt_hash TEXT NOT NULL,
+            response_content TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            hits_count INTEGER DEFAULT 1,
+            ttl_expiry TIMESTAMP,
+            file_size INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("f", "p", {"b": 2}, "r", "{}")
+    res = cache.get_cached_result("f", "p")
+    assert res["analysis_data"] == {"b": 2}
+    assert res["resume"] == "r"
+    assert res["raw_response"] == "{}"


### PR DESCRIPTION
## Summary
- extend `cache_prompts` schema with `document_resume` and `raw_llm_response`
- return resume and raw_response from `get_cached_result`
- store resume and raw_response when caching results
- add tests covering new cache metadata

## Testing
- `pytest content_analyzer/tests/test_cache_complete.py -q`
- `pytest -q` *(fails: AttributeError: 'ContentAnalyzer' object has no attribute '_parse_api_response', and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_6857fddd58f48320b0eab5a866724af6