### PR TITLE
Fix cache behavior and update tests

### DIFF
--- a/content_analyzer/tests/test_cache_manager.py
+++ b/content_analyzer/tests/test_cache_manager.py
@@ -14,7 +14,9 @@ def test_store_and_retrieve(tmp_path):
     cache = CacheManager(db_file, ttl_hours=1)
     cache.store_result("hash1", "ph1", {"result": "ok"})
     result = cache.get_cached_result("hash1", "ph1")
-    assert result == {"result": "ok"}
+    assert result["analysis_data"] == {"result": "ok"}
+    assert result["resume"] == ""
+    assert result["raw_response"] == ""
 
 
 def test_cache_expiration(tmp_path):

--- a/content_analyzer/tests/test_content_analyzer.py
+++ b/content_analyzer/tests/test_content_analyzer.py
@@ -65,8 +65,11 @@ def test_analyze_batch(tmp_path):
     assert result["status"] == "completed"
     assert result["files_processed"] == 3
     conn = sqlite3.connect(out_db)
-    count = conn.execute(
+    completed = conn.execute(
         "SELECT COUNT(*) FROM fichiers WHERE status='completed'"
     ).fetchone()[0]
+    cached = conn.execute(
+        "SELECT COUNT(*) FROM fichiers WHERE status='cached'"
+    ).fetchone()[0]
     conn.close()
-    assert count == 3
+    assert completed + cached == 3


### PR DESCRIPTION
## Summary
- preserve real status when updating DB during batch analysis
- adjust cache manager test for new return format
- update analyze_batch test to count both cached and completed files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685826d869e48320bd8b091fe6b5516d