### PR TITLE
Remove hard limit on pending file retrieval

### DIFF
--- a/content_analyzer/content_analyzer.py
+++ b/content_analyzer/content_analyzer.py
@@ -295,11 +295,22 @@ class ContentAnalyzer:
     # ------------------------------------------------------------------
     # Batch analysis helper
     # ------------------------------------------------------------------
-    def analyze_batch(self, csv_file: Path, output_db: Path) -> Dict[str, Any]:
-        """Analyse un ensemble de fichiers listés dans un CSV."""
+    def analyze_batch(
+        self,
+        csv_file: Path,
+        output_db: Path,
+        max_files: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Analyse un ensemble de fichiers listés dans un CSV.
+
+        Args:
+            csv_file: Fichier CSV SMBeagle enrichi.
+            output_db: Base SQLite de sortie.
+            max_files: Nombre maximum de fichiers à analyser. ``None`` pour tout traiter.
+        """
         parse_res = self.csv_parser.parse_csv(csv_file, output_db)
         self.db_manager = DBManager(output_db)
-        files = self.db_manager.get_pending_files(limit=100000)
+        files = self.db_manager.get_pending_files(limit=max_files)
 
         processed = 0
         start_time = time.perf_counter()

--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -134,11 +134,17 @@ class DBManager:
         conn.close()
 
     def get_pending_files(
-        self, limit: Optional[int] = 100, priority_threshold: int = 0
+        self,
+        limit: Optional[int] = None,
+        priority_threshold: int = 0,
+        offset: int = 0,
     ) -> List[Dict[str, Any]]:
         """Return pending files ordered by priority.
 
-        If ``limit`` is ``None`` or ``<= 0`` all matching files are returned.
+        Args:
+            limit: Maximum files to return. ``None`` means no limit.
+            priority_threshold: Minimum priority score required.
+            offset: Row offset for pagination.
         """
         conn = self._connect()
         cursor = conn.cursor()
@@ -151,6 +157,12 @@ class DBManager:
         if limit is not None and limit > 0:
             query += " LIMIT ?"
             params.append(limit)
+        if offset > 0:
+            if "LIMIT" not in query:
+                query += " LIMIT -1"
+            query += " OFFSET ?"
+            params.append(offset)
+
         rows = cursor.execute(query, params).fetchall()
         columns = [desc[0] for desc in cursor.description]
         conn.close()

--- a/gui/utils/analysis_thread.py
+++ b/gui/utils/analysis_thread.py
@@ -43,7 +43,7 @@ class AnalysisThread(threading.Thread):
             analyzer = ContentAnalyzer(self.config_path)
             parse_res = analyzer.csv_parser.parse_csv(self.csv_file, self.output_db)
             db_mgr = DBManager(self.output_db)
-            files = db_mgr.get_pending_files(limit=100000)
+            files = db_mgr.get_pending_files(limit=None)
             total = len(files)
             processed = 0
             for row in files:


### PR DESCRIPTION
## Summary
- support unlimited records via `get_pending_files()` limit parameter
- allow optional `max_files` in `analyze_batch`
- fetch all pending files in analysis thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be2abb0e08320a208f3fc6e898477