### PR TITLE
Improve duplicate detection with FastHash+Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Legal : Analyse de contrats et documents juridiques
 
 Architecture Modulaire
 
-Cache intelligent : SQLite basé sur FastHash pour éviter les analyses redondantes
+Cache intelligent : SQLite basé sur une clé FastHash+Taille pour éviter les analyses redondantes
 Filtrage avancé : Exclusions configurables et scoring de priorité
 Templates de prompts : Configuration flexible via Jinja2 et YAML
 Interface graphique : GUI complète pour la gestion et le monitoring
@@ -95,7 +95,7 @@ Le module génère une base SQLite avec :
 
 Table fichiers : Métadonnées SMBeagle + état traitement
 Table reponses_llm : Analyses structurées par domaine
-Table cache_prompts : Cache basé sur FastHash
+Table cache_prompts : Cache basé sur une clé FastHash+Taille
 Table metriques : Monitoring performance
 
 Stack technique
@@ -178,7 +178,7 @@ Limitations
 Dépend de la disponibilité de l'API-DOC-IA
 Qualité d'analyse liée à la qualité des prompts et du modèle LLM
 Formats de fichiers limités à ceux supportés par l'API
-Cache basé sur FastHash : modifications mineures non détectées
+Cache basé sur FastHash+Taille : moins de faux positifs mais modifications mineures non détectées
 
 Support
 Les logs détaillés facilitent le diagnostic des problèmes. Les erreurs courantes sont documentées dans la configuration et l'interface GUI fournit des messages d'erreur explicites.

--- a/content_analyzer/content_analyzer.py
+++ b/content_analyzer/content_analyzer.py
@@ -68,7 +68,9 @@ class ContentAnalyzer:
             value /= 1024
         return f"{value:.1f}PB"
 
-    def _extract_domain_confidences(self, llm_response: Dict[str, Any]) -> Dict[str, int]:
+    def _extract_domain_confidences(
+        self, llm_response: Dict[str, Any]
+    ) -> Dict[str, int]:
         """Return confidence per domain from LLM response."""
         confidences: Dict[str, int] = {}
         for domain in ["security", "rgpd", "finance", "legal"]:
@@ -239,6 +241,7 @@ class ContentAnalyzer:
                 cached = self.cache_manager.get_cached_result(
                     file_row.get("fast_hash", ""),
                     "default_prompt_hash",
+                    file_row.get("file_size"),
                 )
             if cached:
                 return {
@@ -278,6 +281,7 @@ class ContentAnalyzer:
                     parsed_result.get("result", {}),
                     parsed_result.get("resume", ""),
                     parsed_result.get("raw_response", ""),
+                    file_row.get("file_size"),
                 )
 
             return {

--- a/content_analyzer/tests/test_cache_complete.py
+++ b/content_analyzer/tests/test_cache_complete.py
@@ -1,4 +1,5 @@
 import sqlite3
+import time
 from pathlib import Path
 import sys
 
@@ -10,8 +11,10 @@ from content_analyzer.modules.cache_manager import CacheManager
 def test_cache_stores_resume_and_raw_response(tmp_path):
     db_file = tmp_path / "cache.db"
     cache = CacheManager(db_file, ttl_hours=1)
-    cache.store_result("fast", "prompt", {"a": 1}, "short resume", '{"raw": true}')
-    res = cache.get_cached_result("fast", "prompt")
+    cache.store_result(
+        "fast", "prompt", {"a": 1}, "short resume", '{"raw": true}', file_size=5
+    )
+    res = cache.get_cached_result("fast", "prompt", file_size=5)
     assert res["analysis_data"] == {"a": 1}
     assert res["resume"] == "short resume"
     assert res["raw_response"] == '{"raw": true}'
@@ -37,8 +40,27 @@ def test_backward_compatibility_existing_cache(tmp_path):
     conn.close()
 
     cache = CacheManager(db_file, ttl_hours=1)
-    cache.store_result("f", "p", {"b": 2}, "r", "{}")
-    res = cache.get_cached_result("f", "p")
+    cache.store_result("f", "p", {"b": 2}, "r", "{}", file_size=6)
+    res = cache.get_cached_result("f", "p", file_size=6)
     assert res["analysis_data"] == {"b": 2}
     assert res["resume"] == "r"
     assert res["raw_response"] == "{}"
+
+
+def test_legacy_key_retrieval(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    # insert legacy entry without file size in key
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        """
+        INSERT INTO cache_prompts (cache_key, prompt_hash, response_content, ttl_expiry, file_size, document_resume, raw_llm_response)
+        VALUES (?, ?, ?, ?, ?, '', '')
+        """,
+        ("legacyhash_ph", "ph", '{"c":3}', time.time() + 3600, 7),
+    )
+    conn.commit()
+    conn.close()
+
+    res = cache.get_cached_result("legacyhash", "ph", file_size=7)
+    assert res["analysis_data"] == {"c": 3}

--- a/content_analyzer/tests/test_cache_manager.py
+++ b/content_analyzer/tests/test_cache_manager.py
@@ -12,8 +12,8 @@ from content_analyzer.modules.cache_manager import CacheManager
 def test_store_and_retrieve(tmp_path):
     db_file = tmp_path / "cache.db"
     cache = CacheManager(db_file, ttl_hours=1)
-    cache.store_result("hash1", "ph1", {"result": "ok"})
-    result = cache.get_cached_result("hash1", "ph1")
+    cache.store_result("hash1", "ph1", {"result": "ok"}, file_size=1)
+    result = cache.get_cached_result("hash1", "ph1", file_size=1)
     assert result["analysis_data"] == {"result": "ok"}
     assert result["resume"] == ""
     assert result["raw_response"] == ""
@@ -22,17 +22,17 @@ def test_store_and_retrieve(tmp_path):
 def test_cache_expiration(tmp_path):
     db_file = tmp_path / "cache.db"
     cache = CacheManager(db_file, ttl_hours=0)
-    cache.store_result("h", "p", {"a": 1})
-    expired = cache.get_cached_result("h", "p")
+    cache.store_result("h", "p", {"a": 1}, file_size=2)
+    expired = cache.get_cached_result("h", "p", file_size=2)
     assert expired is None
 
 
 def test_hit_rate_calculation(tmp_path):
     db_file = tmp_path / "cache.db"
     cache = CacheManager(db_file, ttl_hours=1)
-    cache.store_result("h", "p", {"a": 1})
-    cache.get_cached_result("h", "p")
-    cache.get_cached_result("h", "p")
+    cache.store_result("h", "p", {"a": 1}, file_size=3)
+    cache.get_cached_result("h", "p", file_size=3)
+    cache.get_cached_result("h", "p", file_size=3)
     stats = cache.get_stats()
     assert stats["total_entries"] == 1
     assert stats["hit_rate"] > 0
@@ -41,7 +41,7 @@ def test_hit_rate_calculation(tmp_path):
 def test_cleanup_expired(tmp_path):
     db_file = tmp_path / "cache.db"
     cache = CacheManager(db_file, ttl_hours=1)
-    cache.store_result("h1", "p", {"a": 1})
+    cache.store_result("h1", "p", {"a": 1}, file_size=4)
     conn = sqlite3.connect(db_file)
     conn.execute("UPDATE cache_prompts SET ttl_expiry = ?", (time.time() - 10,))
     conn.commit()

--- a/content_analyzer/tests/test_duplicate_utils.py
+++ b/content_analyzer/tests/test_duplicate_utils.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.utils.duplicate_utils import create_enhanced_duplicate_key
+
+
+def test_create_enhanced_duplicate_key():
+    assert create_enhanced_duplicate_key("abc", 10) == "abc_10"
+    assert create_enhanced_duplicate_key("abc", None) == "abc"
+    assert create_enhanced_duplicate_key("", 10) == ""

--- a/content_analyzer/utils/__init__.py
+++ b/content_analyzer/utils/__init__.py
@@ -1,1 +1,1 @@
-
+from .duplicate_utils import create_enhanced_duplicate_key

--- a/content_analyzer/utils/duplicate_utils.py
+++ b/content_analyzer/utils/duplicate_utils.py
@@ -1,0 +1,18 @@
+"""Utilities for duplicate detection using FastHash and file size."""
+
+from __future__ import annotations
+
+
+def create_enhanced_duplicate_key(fast_hash: str, file_size: int | None) -> str:
+    """Return composite key combining fast hash and file size.
+
+    Args:
+        fast_hash: Hash of the first 64KB of the file.
+        file_size: Exact file size in bytes.
+
+    Returns:
+        Composite key formatted as "fasthash_size".
+    """
+    if not fast_hash or file_size is None:
+        return fast_hash or ""
+    return f"{fast_hash}_{file_size}"


### PR DESCRIPTION
## Summary
- create `create_enhanced_duplicate_key` utility
- use composite key in `CacheManager`
- update ContentAnalyzer and GUI to pass file size
- adjust duplicate filtering queries
- update README
- add tests for composite key and cache

## Testing
- `black content_analyzer/modules/cache_manager.py content_analyzer/utils/duplicate_utils.py content_analyzer/content_analyzer.py gui/main_window.py content_analyzer/tests/test_cache_manager.py content_analyzer/tests/test_cache_complete.py content_analyzer/tests/test_duplicate_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9bc9f9bc8320b29cdfc8522b190a