### PR TITLE
Fix duplicate detection and add thread-safe cache

### DIFF
--- a/content_analyzer/modules/cache_manager.py
+++ b/content_analyzer/modules/cache_manager.py
@@ -3,6 +3,7 @@ import sqlite3
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+import threading
 
 from content_analyzer.utils import create_enhanced_duplicate_key
 
@@ -16,84 +17,69 @@ class CacheManager:
         self.db_path = db_path
         self.ttl_hours = ttl_hours
         self.max_size_mb = max_size_mb
+        self._lock = threading.RLock()
         self._ensure_schema()
 
     def _connect(self) -> sqlite3.Connection:
         return sqlite3.connect(self.db_path)
 
     def _ensure_schema(self) -> None:
-        conn = self._connect()
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            CREATE TABLE IF NOT EXISTS cache_prompts (
-                cache_key TEXT PRIMARY KEY,
-                prompt_hash TEXT NOT NULL,
-                response_content TEXT NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                hits_count INTEGER DEFAULT 1,
-                ttl_expiry TIMESTAMP,
-                file_size INTEGER
+        with self._lock:
+            conn = self._connect()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache_prompts (
+                    cache_key TEXT PRIMARY KEY,
+                    prompt_hash TEXT NOT NULL,
+                    response_content TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    hits_count INTEGER DEFAULT 1,
+                    ttl_expiry TIMESTAMP,
+                    file_size INTEGER
+                )
+                """
             )
-            """
-        )
-        cursor.execute(
-            "CREATE INDEX IF NOT EXISTS idx_ttl_expiry ON cache_prompts(ttl_expiry)"
-        )
-        cursor.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hits_count ON cache_prompts(hits_count DESC)"
-        )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ttl_expiry ON cache_prompts(ttl_expiry)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hits_count ON cache_prompts(hits_count DESC)"
+            )
 
-        cursor.execute("PRAGMA table_info(cache_prompts)")
-        existing_cols = [row[1] for row in cursor.fetchall()]
-        for col in ["document_resume", "raw_llm_response"]:
-            if col not in existing_cols:
-                cursor.execute(f"ALTER TABLE cache_prompts ADD COLUMN {col} TEXT")
+            cursor.execute("PRAGMA table_info(cache_prompts)")
+            existing_cols = [row[1] for row in cursor.fetchall()]
+            for col in ["document_resume", "raw_llm_response"]:
+                if col not in existing_cols:
+                    cursor.execute(
+                        f"ALTER TABLE cache_prompts ADD COLUMN {col} TEXT"
+                    )
 
-        conn.commit()
-        conn.close()
+            conn.commit()
+            conn.close()
 
     def get_cached_result(
         self, fast_hash: str, prompt_hash: str, file_size: Optional[int] = None
     ) -> Optional[Dict[str, Any]]:
-        enhanced = create_enhanced_duplicate_key(fast_hash, file_size)
-        key = f"{enhanced}_{prompt_hash}"
-        conn = self._connect()
-        cursor = conn.cursor()
-        row = cursor.execute(
-            "SELECT response_content, document_resume, raw_llm_response, hits_count, ttl_expiry FROM cache_prompts WHERE cache_key = ?",
-            (key,),
-        ).fetchone()
-        result = None
-        if row:
-            expiry = row[4]
-            if expiry and time.time() > float(expiry):
-                conn.execute("DELETE FROM cache_prompts WHERE cache_key = ?", (key,))
-                conn.commit()
-            else:
-                conn.execute(
-                    "UPDATE cache_prompts SET hits_count = hits_count + 1 WHERE cache_key = ?",
-                    (key,),
-                )
-                conn.commit()
-                result = {
-                    "analysis_data": json.loads(row[0]),
-                    "resume": row[1] or "",
-                    "raw_response": row[2] or "",
-                }
-        if row is None and file_size is not None:
-            legacy_key = f"{fast_hash}_{prompt_hash}"
+        with self._lock:
+            enhanced = create_enhanced_duplicate_key(fast_hash, file_size)
+            key = f"{enhanced}_{prompt_hash}"
+            conn = self._connect()
+            cursor = conn.cursor()
             row = cursor.execute(
                 "SELECT response_content, document_resume, raw_llm_response, hits_count, ttl_expiry FROM cache_prompts WHERE cache_key = ?",
-                (legacy_key,),
+                (key,),
             ).fetchone()
-            key = legacy_key if row else key
+            result = None
             if row:
                 expiry = row[4]
-                if not (expiry and time.time() > float(expiry)):
+                if expiry and time.time() > float(expiry):
+                    conn.execute("DELETE FROM cache_prompts WHERE cache_key = ?", (key,))
+                    conn.commit()
+                else:
                     conn.execute(
                         "UPDATE cache_prompts SET hits_count = hits_count + 1 WHERE cache_key = ?",
-                        (legacy_key,),
+                        (key,),
                     )
                     conn.commit()
                     result = {
@@ -101,9 +87,29 @@ class CacheManager:
                         "resume": row[1] or "",
                         "raw_response": row[2] or "",
                     }
+            if row is None and file_size is not None:
+                legacy_key = f"{fast_hash}_{prompt_hash}"
+                row = cursor.execute(
+                    "SELECT response_content, document_resume, raw_llm_response, hits_count, ttl_expiry FROM cache_prompts WHERE cache_key = ?",
+                    (legacy_key,),
+                ).fetchone()
+                key = legacy_key if row else key
+                if row:
+                    expiry = row[4]
+                    if not (expiry and time.time() > float(expiry)):
+                        conn.execute(
+                            "UPDATE cache_prompts SET hits_count = hits_count + 1 WHERE cache_key = ?",
+                            (legacy_key,),
+                        )
+                        conn.commit()
+                        result = {
+                            "analysis_data": json.loads(row[0]),
+                            "resume": row[1] or "",
+                            "raw_response": row[2] or "",
+                        }
 
-        conn.close()
-        return result
+            conn.close()
+            return result
 
     def store_result(
         self,
@@ -114,77 +120,79 @@ class CacheManager:
         raw_llm_response: str = "",
         file_size: Optional[int] = None,
     ) -> None:
-        enhanced = create_enhanced_duplicate_key(fast_hash, file_size)
-        key = f"{enhanced}_{prompt_hash}"
-        expiry = time.time() + self.ttl_hours * 3600
-        conn = self._connect()
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO cache_prompts (
-                cache_key,
-                prompt_hash,
-                response_content,
-                ttl_expiry,
-                file_size,
-                document_resume,
-                raw_llm_response
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                key,
-                prompt_hash,
-                json.dumps(result),
-                expiry,
-                file_size if file_size is not None else result.get("file_size"),
-                document_resume,
-                raw_llm_response,
-            ),
-        )
-        conn.commit()
-        conn.close()
+        with self._lock:
+            enhanced = create_enhanced_duplicate_key(fast_hash, file_size)
+            key = f"{enhanced}_{prompt_hash}"
+            expiry = time.time() + self.ttl_hours * 3600
+            conn = self._connect()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO cache_prompts (
+                    cache_key,
+                    prompt_hash,
+                    response_content,
+                    ttl_expiry,
+                    file_size,
+                    document_resume,
+                    raw_llm_response
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key,
+                    prompt_hash,
+                    json.dumps(result),
+                    expiry,
+                    file_size if file_size is not None else result.get("file_size"),
+                    document_resume,
+                    raw_llm_response,
+                ),
+            )
+            conn.commit()
+            conn.close()
 
     def cleanup_expired(self) -> int:
-        now = time.time()
-        conn = self._connect()
-        cursor = conn.cursor()
-        cursor.execute(
-            "DELETE FROM cache_prompts WHERE ttl_expiry IS NOT NULL AND ttl_expiry <= ?",
-            (now,),
-        )
-        deleted = cursor.rowcount
-        conn.commit()
-        conn.close()
-        return deleted
+        with self._lock:
+            now = time.time()
+            conn = self._connect()
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM cache_prompts WHERE ttl_expiry IS NOT NULL AND ttl_expiry <= ?",
+                (now,),
+            )
+            deleted = cursor.rowcount
+            conn.commit()
+            conn.close()
+            return deleted
 
     def cleanup_expired_and_oversized(self) -> Dict[str, int]:
         """Nettoie les entrées expirées et si la taille dépasse la limite."""
-        stats = {"expired_deleted": 0, "oversized_deleted": 0}
+        with self._lock:
+            stats = {"expired_deleted": 0, "oversized_deleted": 0}
+            stats["expired_deleted"] = self.cleanup_expired()
 
-        stats["expired_deleted"] = self.cleanup_expired()
+            size_mb = Path(self.db_path).stat().st_size / (1024 * 1024)
+            if size_mb <= self.max_size_mb:
+                return stats
 
-        size_mb = Path(self.db_path).stat().st_size / (1024 * 1024)
-        if size_mb <= self.max_size_mb:
+            conn = self._connect()
+            cursor = conn.cursor()
+            to_remove = size_mb - self.max_size_mb
+            cursor.execute(
+                "SELECT cache_key, file_size FROM cache_prompts ORDER BY hits_count ASC, created_at ASC"
+            )
+            removed_mb = 0.0
+            keys_to_delete = []
+            for key, file_size in cursor.fetchall():
+                removed_mb += (file_size or 0) / (1024 * 1024)
+                keys_to_delete.append(key)
+                if removed_mb >= to_remove:
+                    break
+            for key in keys_to_delete:
+                cursor.execute("DELETE FROM cache_prompts WHERE cache_key = ?", (key,))
+            stats["oversized_deleted"] = len(keys_to_delete)
+            conn.commit()
+            conn.close()
             return stats
-
-        conn = self._connect()
-        cursor = conn.cursor()
-        to_remove = size_mb - self.max_size_mb
-        cursor.execute(
-            "SELECT cache_key, file_size FROM cache_prompts ORDER BY hits_count ASC, created_at ASC"
-        )
-        removed_mb = 0.0
-        keys_to_delete = []
-        for key, file_size in cursor.fetchall():
-            removed_mb += (file_size or 0) / (1024 * 1024)
-            keys_to_delete.append(key)
-            if removed_mb >= to_remove:
-                break
-        for key in keys_to_delete:
-            cursor.execute("DELETE FROM cache_prompts WHERE cache_key = ?", (key,))
-        stats["oversized_deleted"] = len(keys_to_delete)
-        conn.commit()
-        conn.close()
-        return stats
 
     def schedule_automatic_cleanup(self) -> None:
         """Planifie un nettoyage automatique quotidien."""
@@ -199,25 +207,26 @@ class CacheManager:
         Timer(24 * 3600, _cleanup).start()
 
     def get_stats(self) -> Dict[str, Any]:
-        conn = self._connect()
-        cursor = conn.cursor()
-        total = cursor.execute("SELECT COUNT(*) FROM cache_prompts").fetchone()[0]
-        hits = (
-            cursor.execute("SELECT SUM(hits_count) FROM cache_prompts").fetchone()[0]
-            or 0
-        )
-        oldest_row = cursor.execute(
-            "SELECT MIN(created_at) FROM cache_prompts"
-        ).fetchone()[0]
-        size_bytes = Path(self.db_path).stat().st_size
-        conn.close()
-        hit_rate = 0.0
-        if hits and total:
-            hit_rate = (hits - total) / hits * 100
-        return {
-            "total_entries": total,
-            "hit_rate": round(hit_rate, 2),
-            "cache_size_mb": round(size_bytes / (1024 * 1024), 2),
-            "oldest_entry": oldest_row,
-            "cleanup_needed": total > 10000,
-        }
+        with self._lock:
+            conn = self._connect()
+            cursor = conn.cursor()
+            total = cursor.execute("SELECT COUNT(*) FROM cache_prompts").fetchone()[0]
+            hits = (
+                cursor.execute("SELECT SUM(hits_count) FROM cache_prompts").fetchone()[0]
+                or 0
+            )
+            oldest_row = cursor.execute(
+                "SELECT MIN(created_at) FROM cache_prompts"
+            ).fetchone()[0]
+            size_bytes = Path(self.db_path).stat().st_size
+            conn.close()
+            hit_rate = 0.0
+            if hits and total:
+                hit_rate = (hits - total) / hits * 100
+            return {
+                "total_entries": total,
+                "hit_rate": round(hit_rate, 2),
+                "cache_size_mb": round(size_bytes / (1024 * 1024), 2),
+                "oldest_entry": oldest_row,
+                "cleanup_needed": total > 10000,
+            }

--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -96,6 +96,9 @@ class DBManager:
                 "CREATE INDEX IF NOT EXISTS idx_fast_hash_duplicates ON fichiers(fast_hash) WHERE fast_hash IS NOT NULL AND fast_hash != ''"
             )
             cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_duplicate_detection ON fichiers(fast_hash, file_size) WHERE fast_hash IS NOT NULL AND fast_hash != ''"
+            )
+            cursor.execute(
                 "CREATE INDEX IF NOT EXISTS idx_covering_results ON fichiers(id, name, status, file_size, last_modified, path) WHERE status IN ('completed', 'error')"
             )
         except sqlite3.OperationalError:

--- a/content_analyzer/tests/test_cache_thread_safety.py
+++ b/content_analyzer/tests/test_cache_thread_safety.py
@@ -1,0 +1,32 @@
+import sqlite3
+import threading
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.cache_manager import CacheManager
+from content_analyzer.utils import create_enhanced_duplicate_key
+
+
+def test_cache_thread_safety(tmp_path):
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("h", "p", {"r": 1}, file_size=1)
+
+    def worker():
+        cache.get_cached_result("h", "p", file_size=1)
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    key = f"{create_enhanced_duplicate_key('h', 1)}_p"
+    conn = sqlite3.connect(db_file)
+    hits = conn.execute(
+        "SELECT hits_count FROM cache_prompts WHERE cache_key=?", (key,)
+    ).fetchone()[0]
+    conn.close()
+    assert hits == 11

--- a/content_analyzer/tests/test_duplicate_detection.py
+++ b/content_analyzer/tests/test_duplicate_detection.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.utils.duplicate_utils import detect_duplicates
+
+
+def test_duplicate_detection_scenarios():
+    scenarios = [
+        ("abc123", 1000, "abc123", 1000, True),
+        ("abc123", 1000, "abc123", 2000, False),
+        ("abc123", 1000, "def456", 1000, False),
+        ("", 1000, "", 1000, False),
+        (None, 1000, None, 1000, False),
+        ("abc123", 0, "abc123", 0, True),
+        ("abc123", None, "abc123", None, False),
+        ("abc123", 281474976710656, "abc123", 281474976710656, True),
+        ("abc123", -1, "abc123", -1, False),
+        ("A" * 64, 500, "A" * 64, 500, True),
+        ("abc", 123, "ABC", 123, False),
+        ("hash", 999, "hash", 998, False),
+        ("hash", 999, "hash", 999, True),
+        ("hash1", 0, "hash2", 0, False),
+        ("same", 1, "same", 1, True),
+        ("same", 1, "same", 2, False),
+        ("same", 1, "other", 1, False),
+        ("dup", 281474976710657, "dup", 281474976710657, False),
+        (None, None, None, None, False),
+        ("", None, "", None, False),
+    ]
+    for h1, s1, h2, s2, expected in scenarios:
+        assert detect_duplicates(h1, s1, h2, s2) is expected, f"Failed: {h1},{s1} vs {h2},{s2}"

--- a/content_analyzer/tests/test_duplicate_utils.py
+++ b/content_analyzer/tests/test_duplicate_utils.py
@@ -3,10 +3,20 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from content_analyzer.utils.duplicate_utils import create_enhanced_duplicate_key
+from content_analyzer.utils.duplicate_utils import (
+    create_enhanced_duplicate_key,
+    detect_duplicates,
+)
 
 
 def test_create_enhanced_duplicate_key():
     assert create_enhanced_duplicate_key("abc", 10) == "abc_10"
-    assert create_enhanced_duplicate_key("abc", None) == "abc"
-    assert create_enhanced_duplicate_key("", 10) == ""
+    invalid = create_enhanced_duplicate_key("abc", None)
+    assert invalid.startswith("INVALID_SIZE_abc_")
+    invalid2 = create_enhanced_duplicate_key("", 10)
+    assert invalid2.startswith("INVALID_HASH_")
+
+
+def test_detect_duplicates_basic():
+    assert detect_duplicates("h1", 1, "h1", 1) is True
+    assert detect_duplicates("h1", 1, "h1", 2) is False

--- a/content_analyzer/utils/__init__.py
+++ b/content_analyzer/utils/__init__.py
@@ -1,1 +1,13 @@
-from .duplicate_utils import create_enhanced_duplicate_key
+"""Convenience exports for common utilities."""
+
+from .duplicate_utils import (
+    create_enhanced_duplicate_key,
+    detect_duplicates,
+    ThreadSafeDuplicateKeyGenerator,
+)
+
+__all__ = [
+    "create_enhanced_duplicate_key",
+    "detect_duplicates",
+    "ThreadSafeDuplicateKeyGenerator",
+]

--- a/content_analyzer/utils/duplicate_utils.py
+++ b/content_analyzer/utils/duplicate_utils.py
@@ -1,18 +1,96 @@
-"""Utilities for duplicate detection using FastHash and file size."""
+"""Utilities for duplicate detection using FastHash and file size.
+
+This module provides a thread-safe generator for composite duplicate keys
+as well as helpers used throughout the project when dealing with
+FastHash/file size deduplication.  Previous implementations simply
+concatenated the hash and the size and returned an empty string for invalid
+values which led to collisions.  The new implementation guarantees unique
+keys even for edge cases and validates the inputs thoroughly.
+"""
 
 from __future__ import annotations
 
+from typing import Optional
+import threading
 
-def create_enhanced_duplicate_key(fast_hash: str, file_size: int | None) -> str:
-    """Return composite key combining fast hash and file size.
 
-    Args:
-        fast_hash: Hash of the first 64KB of the file.
-        file_size: Exact file size in bytes.
+class ThreadSafeDuplicateKeyGenerator:
+    """Generate duplicate detection keys in a thread-safe manner."""
 
-    Returns:
-        Composite key formatted as "fasthash_size".
-    """
-    if not fast_hash or file_size is None:
-        return fast_hash or ""
-    return f"{fast_hash}_{file_size}"
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        # Small cache to avoid recreating the same key strings repeatedly
+        # in high concurrency scenarios.  Mapping ``(hash, size)`` -> key.
+        self._key_cache: dict[tuple[str, int], str] = {}
+
+    def create_enhanced_duplicate_key(
+        self, fast_hash: str, file_size: Optional[int]
+    ) -> str:
+        """Return a robust composite key for the given inputs.
+
+        The function ensures that edge cases such as missing hashes or invalid
+        file sizes always yield a unique key in order to prevent collisions in
+        the cache layer.
+        """
+
+        with self._lock:
+            if not fast_hash or not isinstance(fast_hash, str):
+                # ``id`` provides uniqueness for the given object instance
+                return f"INVALID_HASH_{id(fast_hash)}_{file_size or 0}"
+
+            if file_size is None or file_size < 0:
+                return f"INVALID_SIZE_{fast_hash}_{file_size or 'None'}"
+
+            if file_size > 281_474_976_710_656:
+                return f"OVERFLOW_{fast_hash}_{file_size}"
+
+            key_tuple = (fast_hash, int(file_size))
+            cached = self._key_cache.get(key_tuple)
+            if cached is not None:
+                return cached
+
+            result = f"{fast_hash}_{file_size}"
+            self._key_cache[key_tuple] = result
+            # Prevent unbounded growth; keep only a few hundred entries
+            if len(self._key_cache) > 1024:
+                self._key_cache.pop(next(iter(self._key_cache)))
+            return result
+
+
+_GENERATOR = ThreadSafeDuplicateKeyGenerator()
+
+
+def create_enhanced_duplicate_key(fast_hash: str, file_size: Optional[int]) -> str:
+    """Compatibility wrapper around :class:`ThreadSafeDuplicateKeyGenerator`."""
+
+    return _GENERATOR.create_enhanced_duplicate_key(fast_hash, file_size)
+
+
+def detect_duplicates(
+    fast_hash1: Optional[str],
+    file_size1: Optional[int],
+    fast_hash2: Optional[str],
+    file_size2: Optional[int],
+) -> bool:
+    """Return ``True`` if the two files should be considered duplicates."""
+
+    if not fast_hash1 or not fast_hash2:
+        return False
+
+    if file_size1 is None or file_size2 is None:
+        return False
+
+    if file_size1 < 0 or file_size2 < 0:
+        return False
+
+    if file_size1 > 281_474_976_710_656 or file_size2 > 281_474_976_710_656:
+        return False
+
+    return fast_hash1 == fast_hash2 and file_size1 == file_size2
+
+
+__all__ = [
+    "create_enhanced_duplicate_key",
+    "ThreadSafeDuplicateKeyGenerator",
+    "detect_duplicates",
+]

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1959,10 +1959,11 @@ No need to run analysis to see your files.
                         base_query += (
                             " AND EXISTS ("
                             "SELECT 1 FROM fichiers f2 "
-                            "WHERE f2.fast_hash = f.fast_hash "
-                            "AND f2.file_size = f.file_size "
+                            "WHERE f.fast_hash = f2.fast_hash "
+                            "AND f.file_size = f2.file_size "
+                            "AND f.fast_hash IS NOT NULL AND f.fast_hash != '' "
                             "AND f2.fast_hash IS NOT NULL AND f2.fast_hash != '' "
-                            "AND f2.id != f.id)"
+                            "AND f.id != f2.id)"
                         )
 
                     # Verify file existence with current filters
@@ -2176,10 +2177,11 @@ No need to run analysis to see your files.
             base_query += (
                 " AND EXISTS ("
                 "SELECT 1 FROM fichiers f2 "
-                "WHERE f2.fast_hash = f.fast_hash "
-                "AND f2.file_size = f.file_size "
+                "WHERE f.fast_hash = f2.fast_hash "
+                "AND f.file_size = f2.file_size "
+                "AND f.fast_hash IS NOT NULL AND f.fast_hash != '' "
                 "AND f2.fast_hash IS NOT NULL AND f2.fast_hash != '' "
-                "AND f2.id != f.id)"
+                "AND f.id != f2.id)"
             )
 
         base_query += " ORDER BY f.id DESC LIMIT ? OFFSET ?"
@@ -2737,10 +2739,11 @@ RAW RESPONSE:
                 query += (
                     " AND EXISTS ("
                     "SELECT 1 FROM fichiers f2 "
-                    "WHERE f2.fast_hash = f.fast_hash "
-                    "AND f2.file_size = f.file_size "
+                    "WHERE f.fast_hash = f2.fast_hash "
+                    "AND f.file_size = f2.file_size "
+                    "AND f.fast_hash IS NOT NULL AND f.fast_hash != '' "
                     "AND f2.fast_hash IS NOT NULL AND f2.fast_hash != '' "
-                    "AND f2.id != f.id)"
+                    "AND f.id != f2.id)"
                 )
 
             cursor.execute(query, params)


### PR DESCRIPTION
## Summary
- improve duplicate key generation with thread safety and edge case handling
- lock cache manager access and fix cleanup routines
- add composite index for duplicate detection
- fix GUI SQL queries for duplicates
- add extensive duplicate detection tests and cache concurrency test

## Testing
- `python -m pytest content_analyzer/tests/test_duplicate_detection.py -v`
- `python -m pytest content_analyzer/tests/test_cache_thread_safety.py -v`
- `python -m pytest content_analyzer/tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_685fac22e94c8320aa7cb3e8ec1f548c