### PR TITLE
Fix sqlite thread safety via connection pool

### DIFF
--- a/content_analyzer/tests/test_cache_connection_pool.py
+++ b/content_analyzer/tests/test_cache_connection_pool.py
@@ -1,0 +1,27 @@
+import threading
+import sqlite3
+from pathlib import Path
+from content_analyzer.modules.cache_manager import CacheManager
+from content_analyzer.utils import create_enhanced_duplicate_key
+
+
+def test_connection_pool_thread_safety(tmp_path: Path) -> None:
+    db_file = tmp_path / "cache.db"
+    cache = CacheManager(db_file, ttl_hours=1)
+    cache.store_result("h", "p", {"r": 1}, file_size=1)
+
+    def worker() -> None:
+        for _ in range(5):
+            cache.get_cached_result("h", "p", file_size=1)
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    key = f"{create_enhanced_duplicate_key('h', 1)}_p"
+    conn = sqlite3.connect(db_file)
+    hits = conn.execute("SELECT hits_count FROM cache_prompts WHERE cache_key=?", (key,)).fetchone()[0]
+    conn.close()
+    assert hits == 1 + 20 * 5

--- a/content_analyzer/utils/__init__.py
+++ b/content_analyzer/utils/__init__.py
@@ -5,9 +5,12 @@ from .duplicate_utils import (
     detect_duplicates,
     ThreadSafeDuplicateKeyGenerator,
 )
+from .sqlite_utils import SQLiteConnectionManager, SQLiteConnectionPool
 
 __all__ = [
     "create_enhanced_duplicate_key",
     "detect_duplicates",
     "ThreadSafeDuplicateKeyGenerator",
+    "SQLiteConnectionManager",
+    "SQLiteConnectionPool",
 ]

--- a/content_analyzer/utils/sqlite_utils.py
+++ b/content_analyzer/utils/sqlite_utils.py
@@ -1,0 +1,48 @@
+import sqlite3
+from pathlib import Path
+from queue import Queue
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class SQLiteConnectionManager:
+    """Context manager for SQLite connections."""
+
+    def __init__(self, db_path: Path, check_same_thread: bool = False) -> None:
+        self.db_path = str(db_path)
+        self.check_same_thread = check_same_thread
+        self.conn: sqlite3.Connection | None = None
+
+    def __enter__(self) -> sqlite3.Connection:
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=self.check_same_thread)
+        return self.conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+
+class SQLiteConnectionPool:
+    """Simple thread-safe connection pool."""
+
+    def __init__(self, db_path: Path, pool_size: int = 5) -> None:
+        self.db_path = str(db_path)
+        self.pool: Queue[sqlite3.Connection] = Queue(maxsize=pool_size)
+        for _ in range(pool_size):
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            self.pool.put(conn)
+
+    @contextmanager
+    def get(self) -> Iterator[sqlite3.Connection]:
+        conn = self.pool.get()
+        try:
+            yield conn
+        finally:
+            self.pool.put(conn)
+
+    def close(self) -> None:
+        while not self.pool.empty():
+            conn = self.pool.get_nowait()
+            conn.close()
+


### PR DESCRIPTION
## Summary
- add SQLiteConnectionPool and context manager helpers
- use thread-safe connection pool in CacheManager
- update DBManager to use connection context manager
- enhance GUI cleanup and event binding
- add test for connection pool thread safety

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6860353c388c8320b0e34937d75b29bb