### PR TITLE
Fix resource cleanup with context managers

### DIFF
--- a/content_analyzer/content_analyzer.py
+++ b/content_analyzer/content_analyzer.py
@@ -58,6 +58,25 @@ class ContentAnalyzer:
         self.api_client = APIClient(self.config)
         self.db_manager = DBManager(Path("analysis_results.db"))
         self.prompt_manager = PromptManager(self.config_path)
+        self._closed = False
+
+    def close(self) -> None:
+        """Close underlying managers."""
+        if self._closed:
+            return
+        self.cache_manager.close()
+        self.api_client.close()
+        self.db_manager.close()
+        self._closed = True
+
+    def __enter__(self) -> "ContentAnalyzer":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
 
     def _format_file_size(self, size: int) -> str:
         units = ["B", "KB", "MB", "GB", "TB"]

--- a/content_analyzer/modules/api_client.py
+++ b/content_analyzer/modules/api_client.py
@@ -17,6 +17,10 @@ class APIClient:
         self.token = config["api_config"].get("token")
         self.timeout = config["api_config"].get("timeout_seconds", 300)
         self.session = requests.Session()
+        self._closed = False
+
+    def __del__(self) -> None:
+        self.close()
 
     def _headers(self) -> Dict[str, str]:
         return {"Authorization": f"Bearer {self.token}"}
@@ -71,3 +75,15 @@ class APIClient:
         except requests.RequestException as exc:
             logger.warning("Health check failed: %s", exc)
             return False
+
+    def close(self) -> None:
+        """Close underlying HTTP session."""
+        if not self._closed:
+            self.session.close()
+            self._closed = True
+
+    def __enter__(self) -> "APIClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/gui/utils/service_monitor.py
+++ b/gui/utils/service_monitor.py
@@ -21,15 +21,15 @@ class ServiceMonitor:
 
     def check_api_status(self) -> bool:
         cfg = self._load_config()
-        client = APIClient(cfg)
-        return client.health_check()
+        with APIClient(cfg) as client:
+            return client.health_check()
 
     def check_cache_status(self) -> Dict[str, float]:
         cache_db = Path("analysis_results_cache.db")
         if not cache_db.exists():
             return {"hit_rate": 0.0}
-        cache = CacheManager(cache_db)
-        return cache.get_stats()
+        with CacheManager(cache_db) as cache:
+            return cache.get_stats()
 
     def check_database_status(self) -> Dict[str, float]:
         db_path = Path("analysis_results.db")
@@ -52,9 +52,9 @@ class ServiceMonitor:
     def _measure_api_response_time(self) -> float:
         try:
             cfg = self._load_config()
-            client = APIClient(cfg)
-            start = time.time()
-            ok = client.health_check()
+            with APIClient(cfg) as client:
+                start = time.time()
+                ok = client.health_check()
             if not ok:
                 return -1.0
             return (time.time() - start) * 1000


### PR DESCRIPTION
## Summary
- add close method and context manager to CacheManager
- add resource cleanup context to DBManager
- provide close handling in APIClient
- ensure ContentAnalyzer propagates resource cleanup
- use context managers in AnalysisThread and ServiceMonitor
- fix early connection closure bug in DBManager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68604af0f4f883208a4870bc0fc70888