### PR TITLE
Centralize duplicate detection logic

### DIFF
--- a/content_analyzer/modules/duplicate_detector.py
+++ b/content_analyzer/modules/duplicate_detector.py
@@ -1,0 +1,163 @@
+"""Centralized duplicate detection utilities."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from content_analyzer.utils.duplicate_utils import (
+    create_enhanced_duplicate_key,
+    detect_duplicates,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FileInfo:
+    """Standardized structure for file metadata."""
+
+    id: int
+    path: str
+    fast_hash: Optional[str]
+    file_size: int
+    creation_time: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+class DuplicateDetector:
+    """Central duplicate detection class."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.config = config or {}
+        self.size_limit = 281_474_976_710_656
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # Filtering helpers
+    # ------------------------------------------------------------------
+    def should_ignore_file(self, file_info: FileInfo) -> Tuple[bool, str]:
+        """Return whether a file should be ignored from duplicate detection."""
+        if file_info.file_size == 0:
+            return True, "zero_size_file"
+        if file_info.file_size > self.size_limit:
+            return True, "file_too_large"
+        if file_info.fast_hash and "ERROR" in file_info.fast_hash.upper():
+            logger.warning("FastHash error detected for %s", file_info.path)
+            return True, "hash_error"
+        temp_extensions = {".tmp", ".temp", ".~"}
+        if Path(file_info.path).suffix.lower() in temp_extensions:
+            return True, "temporary_file"
+        return False, "ok"
+
+    # ------------------------------------------------------------------
+    def detect_duplicate_family(
+        self, files_list: List[FileInfo]
+    ) -> Dict[str, List[FileInfo]]:
+        """Group files by duplicate family based on hash and size."""
+        families: Dict[str, List[FileInfo]] = {}
+        for info in files_list:
+            ignore, reason = self.should_ignore_file(info)
+            if ignore:
+                logger.debug("Ignoring %s: %s", info.path, reason)
+                continue
+            if not info.fast_hash or not info.fast_hash.strip():
+                logger.debug("No valid hash for %s", info.path)
+                continue
+            key = create_enhanced_duplicate_key(info.fast_hash, info.file_size)
+            families.setdefault(key, []).append(info)
+        return {k: v for k, v in families.items() if len(v) > 1}
+
+    # ------------------------------------------------------------------
+    def is_duplicate_pair(self, file1: FileInfo, file2: FileInfo) -> bool:
+        """Return True if the two file infos represent duplicates."""
+        return detect_duplicates(
+            file1.fast_hash,
+            file1.file_size,
+            file2.fast_hash,
+            file2.file_size,
+        )
+
+    # ------------------------------------------------------------------
+    def identify_source_file(self, duplicate_group: List[FileInfo]) -> FileInfo:
+        """Identify the original source file within a duplicate group."""
+        if not duplicate_group:
+            raise ValueError("Empty duplicate group")
+        if len(duplicate_group) == 1:
+            return duplicate_group[0]
+        sorted_files = sorted(
+            duplicate_group, key=lambda f: self._parse_creation_time(f.creation_time)
+        )
+        source_file = sorted_files[0]
+        logger.info(
+            "Source identified: %s (created: %s)",
+            source_file.path,
+            source_file.creation_time,
+        )
+        return source_file
+
+    # ------------------------------------------------------------------
+    def get_duplicate_statistics(
+        self, duplicate_families: Dict[str, List[FileInfo]]
+    ) -> Dict[str, Any]:
+        """Compute statistics about detected duplicates."""
+        if not duplicate_families:
+            return {
+                "total_families": 0,
+                "total_duplicates": 0,
+                "total_sources": 0,
+                "total_copies": 0,
+                "space_wasted_bytes": 0,
+                "largest_family_size": 0,
+                "families_by_size": {},
+            }
+        total_families = len(duplicate_families)
+        total_files = sum(len(f) for f in duplicate_families.values())
+        total_sources = total_families
+        total_copies = total_files - total_sources
+        space_wasted = 0
+        largest_family = 0
+        families_by_size: Dict[int, int] = {}
+        for fam in duplicate_families.values():
+            family_size = len(fam)
+            largest_family = max(largest_family, family_size)
+            families_by_size[family_size] = families_by_size.get(family_size, 0) + 1
+            if fam:
+                file_size = fam[0].file_size
+                space_wasted += (family_size - 1) * file_size
+        return {
+            "total_families": total_families,
+            "total_duplicates": total_files,
+            "total_sources": total_sources,
+            "total_copies": total_copies,
+            "space_wasted_bytes": space_wasted,
+            "space_wasted_mb": round(space_wasted / (1024 * 1024), 2),
+            "largest_family_size": largest_family,
+            "families_by_size": families_by_size,
+            "average_family_size": round(total_files / total_families, 2)
+            if total_families
+            else 0,
+        }
+
+    # ------------------------------------------------------------------
+    def _parse_creation_time(self, time_str: Optional[str]) -> datetime:
+        if not time_str:
+            return datetime.max
+        formats = ["%d/%m/%Y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"]
+        for fmt in formats:
+            try:
+                return datetime.strptime(time_str.strip(), fmt)
+            except ValueError:
+                continue
+        logger.warning("Could not parse date: %s", time_str)
+        return datetime.max
+
+
+__all__ = [
+    "FileInfo",
+    "DuplicateDetector",
+]

--- a/content_analyzer/tests/test_duplicate_detector.py
+++ b/content_analyzer/tests/test_duplicate_detector.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.duplicate_detector import DuplicateDetector, FileInfo
+
+
+def test_should_ignore_zero_size_files():
+    det = DuplicateDetector()
+    info = FileInfo(id=1, path="/tmp/a.txt", fast_hash="abc", file_size=0)
+    assert det.should_ignore_file(info)[0] is True
+
+
+def test_identify_source_by_creation_date():
+    det = DuplicateDetector()
+    f1 = FileInfo(1, "a", "h", 1, "01/01/2020 10:00:00", None)
+    f2 = FileInfo(2, "b", "h", 1, "02/01/2020 10:00:00", None)
+    src = det.identify_source_file([f2, f1])
+    assert src.id == 1
+
+
+def test_duplicate_family_detection():
+    det = DuplicateDetector()
+    f1 = FileInfo(1, "a", "h", 1)
+    f2 = FileInfo(2, "b", "h", 1)
+    f3 = FileInfo(3, "c", "x", 2)
+    fams = det.detect_duplicate_family([f1, f2, f3])
+    assert len(fams) == 1
+    key, group = next(iter(fams.items()))
+    assert len(group) == 2
+
+
+def test_statistics_calculation():
+    det = DuplicateDetector()
+    f1 = FileInfo(1, "a", "h", 1)
+    f2 = FileInfo(2, "b", "h", 1)
+    fams = det.detect_duplicate_family([f1, f2])
+    stats = det.get_duplicate_statistics(fams)
+    assert stats["total_families"] == 1
+    assert stats["total_copies"] == 1
+
+
+def test_edge_cases_hash_errors():
+    det = DuplicateDetector()
+    info = FileInfo(1, "a.tmp", "ERROR123", 10)
+    ignore, reason = det.should_ignore_file(info)
+    assert ignore is True
+    assert reason == "hash_error"


### PR DESCRIPTION
## Summary
- implement `DuplicateDetector` module with `FileInfo` dataclass
- integrate duplicate filtering in GUI and cache manager
- add unit tests for new duplicate detector

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest content_analyzer/tests/test_duplicate_detector.py -q`
- `python -m pytest content_analyzer/tests/test_cache_manager.py -q`
- `python -m pytest content_analyzer/tests/test_duplicate_utils.py -q`
- `python -m pytest content_analyzer/tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_6860e31229348320be0dc1cb173c9c43