### PR TITLE
Add age and size analysis modules

### DIFF
--- a/content_analyzer/modules/__init__.py
+++ b/content_analyzer/modules/__init__.py
@@ -7,6 +7,8 @@ from .file_filter import FileFilter
 from .db_manager import DBManager
 from .prompt_manager import PromptManager
 from .duplicate_detector import DuplicateDetector
+from .age_analyzer import AgeAnalyzer
+from .size_analyzer import SizeAnalyzer
 
 __all__ = [
     "CSVParser",
@@ -16,4 +18,6 @@ __all__ = [
     "DBManager",
     "PromptManager",
     "DuplicateDetector",
+    "AgeAnalyzer",
+    "SizeAnalyzer",
 ]

--- a/content_analyzer/modules/age_analyzer.py
+++ b/content_analyzer/modules/age_analyzer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+from .duplicate_detector import FileInfo
+
+logger = logging.getLogger(__name__)
+
+
+class AgeAnalyzer:
+    """Perform analysis on file ages."""
+
+    def _parse_time(self, value: str) -> datetime:
+        if not value:
+            return datetime.max
+        for fmt in ("%d/%m/%Y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(value.strip(), fmt)
+            except ValueError:
+                continue
+        logger.warning("Could not parse date: %s", value)
+        return datetime.max
+
+    def _get_reliable_time(self, info: FileInfo) -> datetime:
+        for attr in (info.last_modified, info.creation_time):
+            if attr:
+                dt = self._parse_time(attr)
+                if dt != datetime.max:
+                    return dt
+        return datetime.max
+
+    def analyze_age_distribution(self, files: List[FileInfo]) -> Dict[str, Any]:
+        """Return distribution of files per year."""
+        counts: Dict[int, int] = {}
+        for f in files:
+            dt = self._get_reliable_time(f)
+            if dt == datetime.max:
+                continue
+            counts[dt.year] = counts.get(dt.year, 0) + 1
+        total = sum(counts.values())
+        distribution = {
+            str(year): round(count / total * 100, 2) if total else 0
+            for year, count in counts.items()
+        }
+        return {"distribution_by_year": distribution, "total_files": total}
+
+    def identify_stale_files(
+        self, files: List[FileInfo], threshold_days: int
+    ) -> List[FileInfo]:
+        """Return files not modified since threshold."""
+        cutoff = datetime.now() - timedelta(days=threshold_days)
+        stale: List[FileInfo] = []
+        for f in files:
+            dt = self._get_reliable_time(f)
+            if dt != datetime.max and dt <= cutoff:
+                stale.append(f)
+        return stale
+
+    def calculate_archival_candidates(
+        self, files: List[FileInfo], threshold_days: int
+    ) -> Dict[str, Any]:
+        """Return number and size of stale files."""
+        stale = self.identify_stale_files(files, threshold_days)
+        total_size = sum(f.file_size for f in stale)
+        return {
+            "count": len(stale),
+            "total_size_bytes": total_size,
+            "total_size_mb": round(total_size / (1024 * 1024), 2),
+        }
+
+    def get_age_statistics(self, files: List[FileInfo]) -> Dict[str, Any]:
+        """Return basic statistics about file ages."""
+        ages = []
+        now = datetime.now()
+        for f in files:
+            dt = self._get_reliable_time(f)
+            if dt != datetime.max:
+                ages.append((now - dt).days)
+        if not ages:
+            return {"average_days": 0, "min_days": 0, "max_days": 0}
+        return {
+            "average_days": sum(ages) / len(ages),
+            "min_days": min(ages),
+            "max_days": max(ages),
+        }
+
+
+__all__ = ["AgeAnalyzer"]

--- a/content_analyzer/modules/size_analyzer.py
+++ b/content_analyzer/modules/size_analyzer.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from .duplicate_detector import FileInfo
+
+logger = logging.getLogger(__name__)
+
+
+class SizeAnalyzer:
+    """Perform analysis on file sizes."""
+
+    def analyze_size_distribution(self, files: List[FileInfo]) -> Dict[str, Any]:
+        """Return distribution across size buckets."""
+        buckets = {
+            "<1MB": 0,
+            "1-10MB": 0,
+            "10-100MB": 0,
+            ">100MB": 0,
+        }
+        for f in files:
+            size_mb = f.file_size / (1024 * 1024)
+            if size_mb < 1:
+                buckets["<1MB"] += 1
+            elif size_mb < 10:
+                buckets["1-10MB"] += 1
+            elif size_mb < 100:
+                buckets["10-100MB"] += 1
+            else:
+                buckets[">100MB"] += 1
+        total = len(files)
+        distribution = {
+            k: round(v / total * 100, 2) if total else 0 for k, v in buckets.items()
+        }
+        return {"distribution": distribution, "total_files": total}
+
+    def identify_large_files(
+        self, files: List[FileInfo], threshold_mb: int
+    ) -> List[FileInfo]:
+        """Return files larger than threshold."""
+        limit = threshold_mb * 1024 * 1024
+        return [f for f in files if f.file_size >= limit]
+
+    def calculate_space_optimization(
+        self, files: List[FileInfo], threshold_mb: int
+    ) -> Dict[str, Any]:
+        """Return potential space reclaimed by handling large files."""
+        large = self.identify_large_files(files, threshold_mb)
+        total_size = sum(f.file_size for f in large)
+        return {
+            "large_files": len(large),
+            "size_bytes": total_size,
+            "size_mb": round(total_size / (1024 * 1024), 2),
+        }
+
+    def get_size_statistics(self, files: List[FileInfo]) -> Dict[str, Any]:
+        """Return basic statistics about sizes."""
+        if not files:
+            return {"average_mb": 0, "min_mb": 0, "max_mb": 0}
+        sizes = [f.file_size for f in files]
+        return {
+            "average_mb": sum(sizes) / len(sizes) / (1024 * 1024),
+            "min_mb": min(sizes) / (1024 * 1024),
+            "max_mb": max(sizes) / (1024 * 1024),
+        }
+
+
+__all__ = ["SizeAnalyzer"]

--- a/content_analyzer/tests/test_age_analyzer.py
+++ b/content_analyzer/tests/test_age_analyzer.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+from datetime import datetime, timedelta
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.age_analyzer import AgeAnalyzer
+from content_analyzer.modules.duplicate_detector import FileInfo
+
+
+def make_file(id: int, days: int) -> FileInfo:
+    dt = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    return FileInfo(id, f"file{id}.txt", "h", 1024, dt, dt)
+
+
+def test_age_distribution():
+    analyzer = AgeAnalyzer()
+    files = [make_file(1, 10), make_file(2, 400)]
+    dist = analyzer.analyze_age_distribution(files)
+    assert dist["total_files"] == 2
+    assert sum(dist["distribution_by_year"].values()) > 0
+
+
+def test_identify_stale_files():
+    analyzer = AgeAnalyzer()
+    files = [make_file(1, 10), make_file(2, 400)]
+    stale = analyzer.identify_stale_files(files, threshold_days=365)
+    assert len(stale) == 1
+    stale = analyzer.identify_stale_files(files, threshold_days=30)
+    assert len(stale) == 1
+
+
+def test_archival_candidates():
+    analyzer = AgeAnalyzer()
+    files = [make_file(1, 200), make_file(2, 300)]
+    stats = analyzer.calculate_archival_candidates(files, threshold_days=180)
+    assert stats["count"] == 2
+    assert stats["total_size_bytes"] == 2048
+
+
+def test_age_statistics():
+    analyzer = AgeAnalyzer()
+    files = [make_file(1, 1), make_file(2, 2)]
+    stats = analyzer.get_age_statistics(files)
+    assert stats["max_days"] >= 2
+    assert stats["min_days"] >= 1

--- a/content_analyzer/tests/test_size_analyzer.py
+++ b/content_analyzer/tests/test_size_analyzer.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from content_analyzer.modules.size_analyzer import SizeAnalyzer
+from content_analyzer.modules.duplicate_detector import FileInfo
+
+
+def make_file(id: int, size_mb: int) -> FileInfo:
+    return FileInfo(
+        id, f"file{id}.bin", "h", size_mb * 1024 * 1024, "2024-01-01", "2024-01-02"
+    )
+
+
+def test_size_distribution():
+    analyzer = SizeAnalyzer()
+    files = [make_file(1, 1), make_file(2, 50), make_file(3, 200)]
+    dist = analyzer.analyze_size_distribution(files)
+    assert dist["total_files"] == 3
+    assert dist["distribution"][">100MB"] == round(1 / 3 * 100, 2)
+
+
+def test_identify_large_files():
+    analyzer = SizeAnalyzer()
+    files = [make_file(1, 1), make_file(2, 20)]
+    large = analyzer.identify_large_files(files, threshold_mb=10)
+    assert len(large) == 1
+
+
+def test_space_optimization():
+    analyzer = SizeAnalyzer()
+    files = [make_file(1, 5), make_file(2, 20)]
+    stats = analyzer.calculate_space_optimization(files, threshold_mb=10)
+    assert stats["large_files"] == 1
+    assert stats["size_bytes"] == 20 * 1024 * 1024
+
+
+def test_size_statistics():
+    analyzer = SizeAnalyzer()
+    files = [make_file(1, 2), make_file(2, 4)]
+    stats = analyzer.get_size_statistics(files)
+    assert stats["max_mb"] >= 4
+    assert stats["min_mb"] >= 2


### PR DESCRIPTION
## Summary
- implement `AgeAnalyzer` and `SizeAnalyzer` modules
- expose analyzers via `content_analyzer.modules`
- add basic tests for age/size analyzers

## Testing
- `python3 -m flake8 content_analyzer/modules/age_analyzer.py content_analyzer/modules/size_analyzer.py`
- `python3 -m flake8 content_analyzer/tests/test_age_analyzer.py content_analyzer/tests/test_size_analyzer.py`
- `python3 -m black content_analyzer/modules/age_analyzer.py content_analyzer/modules/size_analyzer.py content_analyzer/tests/test_age_analyzer.py content_analyzer/tests/test_size_analyzer.py`
- `make test` *(fails: 16 failed, 54 passed, 2 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68613bf24ac483208a69364bdc0618a8