### PR TITLE
Fix metrics bug and improve analytics caching

### DIFF
--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -152,6 +152,10 @@ class DBManager:
                 "CREATE INDEX IF NOT EXISTS idx_file_analysis ON fichiers(id, fast_hash, file_size) WHERE fast_hash IS NOT NULL",
                 "idx_file_analysis",
             ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_file_analysis_opt ON fichiers(id, fast_hash, file_size) WHERE fast_hash IS NOT NULL",
+                "idx_file_analysis_opt",
+            ),
         ]
 
         for sql, name in critical_indexes:

--- a/content_analyzer/modules/duplicate_detector.py
+++ b/content_analyzer/modules/duplicate_detector.py
@@ -17,7 +17,7 @@ from content_analyzer.utils.duplicate_utils import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(eq=True, frozen=True)
 class FileInfo:
     """Standardized structure for file metadata."""
 


### PR DESCRIPTION
## Summary
- fix `calculate_business_metrics` crash by using file ids and add intelligent caching
- make `FileInfo` hashable
- create additional SQL index for optimal dashboards
- update alert card refresh logic and add error handling helpers

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863058544d08320a7e2afec20a96ec1