### PR TITLE
Fix analytics panel and add business intelligence features

### DIFF
--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -156,6 +156,14 @@ class DBManager:
                 "CREATE INDEX IF NOT EXISTS idx_file_analysis_opt ON fichiers(id, fast_hash, file_size) WHERE fast_hash IS NOT NULL",
                 "idx_file_analysis_opt",
             ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_duplicate_enhanced ON fichiers(fast_hash, file_size) WHERE fast_hash IS NOT NULL AND fast_hash != ''",
+                "idx_duplicate_enhanced",
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_user_analytics ON fichiers(owner, file_size, status) WHERE owner IS NOT NULL",
+                "idx_user_analytics",
+            ),
         ]
 
         for sql, name in critical_indexes:


### PR DESCRIPTION
## Summary
- fix panel initialization and use ID sets for size/age
- add detailed duplicate, temporal, file size, and user tabs
- show global metrics totals and ensure export dialogs stay above
- add indexes for advanced analytics in DBManager
- compute extended business metrics with caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686417e1aa2c83208919eaddcb81207e