### PR TITLE
Fix missing owner field in analytics

### DIFF
--- a/content_analyzer/modules/db_manager.py
+++ b/content_analyzer/modules/db_manager.py
@@ -390,7 +390,7 @@ class DBManager:
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT id, path, fast_hash, file_size, creation_time, last_modified FROM fichiers"
+                "SELECT id, path, fast_hash, file_size, creation_time, last_modified, owner FROM fichiers"
             )
             rows = cursor.fetchall()
         return [
@@ -401,6 +401,7 @@ class DBManager:
                 file_size=row[3] or 0,
                 creation_time=row[4],
                 last_modified=row[5],
+                owner=row[6],
             )
             for row in rows
         ]

--- a/content_analyzer/modules/duplicate_detector.py
+++ b/content_analyzer/modules/duplicate_detector.py
@@ -27,6 +27,7 @@ class FileInfo:
     file_size: int
     creation_time: Optional[str] = None
     last_modified: Optional[str] = None
+    owner: Optional[str] = None
 
 
 class DuplicateDetector:

--- a/gui/analytics_panel.py
+++ b/gui/analytics_panel.py
@@ -902,7 +902,11 @@ class AnalyticsPanel:
         class_map = self._get_classification_map()
         rgpd_map = self._get_rgpd_map()
 
-        large_files = [f for f in files if f.file_size > 100 * 1024 * 1024 and f.owner]
+        large_files = [
+            f
+            for f in files
+            if f.file_size > 100 * 1024 * 1024 and f.owner and f.owner.strip()
+        ]
         large_files_by_user: Dict[str, Dict[str, Any]] = {}
         for f in large_files:
             owner = f.owner or "Inconnu"
@@ -913,7 +917,11 @@ class AnalyticsPanel:
 
         top_large_files = sorted(large_files_by_user.items(), key=lambda x: x[1]["total_size"], reverse=True)[:3]
 
-        c3_files = [f for f in files if class_map.get(f.id) == "C3" and f.owner]
+        c3_files = [
+            f
+            for f in files
+            if class_map.get(f.id) == "C3" and f.owner and f.owner.strip()
+        ]
         c3_by_user: Dict[str, Dict[str, Any]] = {}
         for f in c3_files:
             owner = f.owner or "Inconnu"
@@ -924,7 +932,11 @@ class AnalyticsPanel:
 
         top_c3_files = sorted(c3_by_user.items(), key=lambda x: x[1]["count"], reverse=True)[:3]
 
-        rgpd_critical_files = [f for f in files if rgpd_map.get(f.id) == "critical" and f.owner]
+        rgpd_critical_files = [
+            f
+            for f in files
+            if rgpd_map.get(f.id) == "critical" and f.owner and f.owner.strip()
+        ]
         rgpd_by_user: Dict[str, Dict[str, Any]] = {}
         for f in rgpd_critical_files:
             owner = f.owner or "Inconnu"


### PR DESCRIPTION
## Summary
- extend `FileInfo` with an optional `owner` field
- query owner column in `DBManager.get_all_files_basic`
- handle empty owners when calculating top user metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864266a3f5c832090fe01187b257405