### PR TITLE
Fix adaptive spacing oscillation with worker-aware logic

### DIFF
--- a/content_analyzer/modules/adaptive_pipeline_manager.py
+++ b/content_analyzer/modules/adaptive_pipeline_manager.py
@@ -23,8 +23,9 @@ class PipelineMetrics:
 class AdaptivePipelineManager:
     """Gestionnaire de pipeline avec feedback automatique"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], max_workers: int = 1):
         self.config = config.get("pipeline_config", {}).get("upload_spacing", {})
+        self._max_workers = max_workers
 
         self.current_spacing = self.config.get("initial_delay_seconds", 5.0)
         self.min_spacing = self.config.get("min_delay_seconds", 1.0)
@@ -57,30 +58,32 @@ class AdaptivePipelineManager:
                 avg_time = sum(self.response_times) / len(self.response_times)
                 self.metrics.avg_api_response_time = avg_time
 
-                if len(self.response_times) >= 4:
-                    prev = sum(list(self.response_times)[-4:-1]) / 3
-                    if avg_time < prev * 0.9 or avg_time > prev * 1.1:
-                        step = -self.adjustment_step if avg_time < prev else self.adjustment_step
-                        new = max(self.min_spacing, min(self.current_spacing + step, self.max_spacing))
-                        if new != self.current_spacing:
-                            tag = "amélioration" if step < 0 else "dégradation"
-                            logging.info(f"API en {tag} ({prev:.1f}s→{avg_time:.1f}s) → espacement {self.current_spacing}s → {new}s")
-                            self.current_spacing = self.metrics.current_upload_spacing = new
-                            return
+                max_workers = getattr(self, "_max_workers", None)
+                if max_workers == 1:
+                    logging.debug("Single worker mode: adaptive spacing disabled")
+                    return
+
+                min_safe_spacing = max(self.min_spacing, max_workers) if max_workers else self.min_spacing
+
                 if avg_time > self.threshold:
                     new_spacing = min(self.current_spacing + self.adjustment_step, self.max_spacing)
                     if new_spacing != self.current_spacing:
                         logging.info(
-                            f"API lente ({avg_time:.1f}s) → espacement {self.current_spacing}s → {new_spacing}s"
+                            f"API protection: {avg_time:.1f}s > {self.threshold}s → espacement {self.current_spacing}s → {new_spacing}s"
                         )
                         self.current_spacing = new_spacing
-                elif avg_time < self.threshold:
-                    new_spacing = max(self.current_spacing - self.adjustment_step, self.min_spacing)
+                elif avg_time < self.threshold * 0.5 and self.current_spacing > min_safe_spacing:
+                    new_spacing = max(self.current_spacing - self.adjustment_step, min_safe_spacing)
                     if new_spacing != self.current_spacing:
                         logging.info(
-                            f"API rapide ({avg_time:.1f}s) → espacement {self.current_spacing}s → {new_spacing}s"
+                            f"API optimization: {avg_time:.1f}s < {self.threshold * 0.5:.1f}s → espacement {self.current_spacing}s → {new_spacing}s (min_safe: {min_safe_spacing}s)"
                         )
                         self.current_spacing = new_spacing
+                else:
+                    logging.debug(
+                        f"API stable: {avg_time:.1f}s, espacement maintenu à {self.current_spacing}s"
+                    )
+
                 self.metrics.current_upload_spacing = self.current_spacing
 
     def should_delay_upload(self) -> float:

--- a/gui/utils/multi_worker_analysis_thread.py
+++ b/gui/utils/multi_worker_analysis_thread.py
@@ -313,7 +313,7 @@ class SmartMultiWorkerAnalysisThread(threading.Thread):
         except Exception:
             cfg = {}
 
-        return AdaptivePipelineManager(cfg or {})
+        return AdaptivePipelineManager(cfg or {}, max_workers=self.max_workers)
 
     def _calculate_optimal_workers(self, count: Optional[int]) -> int:
         if count and count > 0:


### PR DESCRIPTION
## Summary
- pass `max_workers` from `SmartMultiWorkerAnalysisThread` into `AdaptivePipelineManager`
- add asymmetric adaptation logic in `record_api_response_time`

## Testing
- `pytest -q` *(fails: test_confidences.py, test_config.py, test_content_analyzer.py, test_error_handling.py, test_file_filter.py, test_prompt_manager.py, test_resume.py)*

------
https://chatgpt.com/codex/tasks/task_e_686823989da883208444ccd39d3af5f8