### PR TITLE
Improve worker interrupt handling and API timeouts

### DIFF
--- a/content_analyzer/config/analyzer_config.yaml
+++ b/content_analyzer/config/analyzer_config.yaml
@@ -2,6 +2,12 @@ api_config:
   batch_size: 1
   max_tokens: 32000
   timeout_seconds: 300
+  http_timeout_seconds: 60
+  adaptive_timeouts:
+    enable: true
+    base_http_timeout: 60
+    worker_factor: 1.5
+    max_http_timeout: 180
   token: sk-d88e3244ae2e4b64a5256c6f4946155a
   url: http://localhost:8080
 circuit_config:

--- a/content_analyzer/modules/adaptive_pipeline_manager.py
+++ b/content_analyzer/modules/adaptive_pipeline_manager.py
@@ -35,6 +35,10 @@ class AdaptivePipelineManager:
         self.buffer_size = self.config.get("buffer_size", 2)
         self.adaptive_enabled = self.config.get("enable_adaptive_spacing", True)
 
+        api_cfg = config.get("api_config", {})
+        self.base_timeout = api_cfg.get("timeout_seconds", 300)
+        self.base_http_timeout = api_cfg.get("http_timeout_seconds", 60)
+
         self.metrics = PipelineMetrics()
         self.response_times = deque(maxlen=10)
         self.lock = threading.Lock()
@@ -96,8 +100,8 @@ class AdaptivePipelineManager:
 
     def get_adaptive_timeouts(self) -> Dict[str, int]:
         """Calcule timeouts adaptatifs basés sur l'espacement actuel."""
-        base_timeout = 300
-        base_http_timeout = 30
+        base_timeout = self.base_timeout
+        base_http_timeout = self.base_http_timeout
 
         adaptive_factor = max(1.0, self.current_spacing / 10.0)
 

--- a/content_analyzer/modules/api_client.py
+++ b/content_analyzer/modules/api_client.py
@@ -1,6 +1,7 @@
 import logging
 import time
-from typing import Any, Dict
+import threading
+from typing import Any, Dict, Optional
 
 import requests
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -16,7 +17,9 @@ class APIClient:
         self.url = config["api_config"]["url"].rstrip("/")
         self.token = config["api_config"].get("token")
         self.base_timeout = config["api_config"].get("timeout_seconds", 300)
-        self.base_http_timeout = 30  # Nouveau: timeout HTTP de base
+        self.base_http_timeout = config["api_config"].get(
+            "http_timeout_seconds", 60
+        )
         self.session = requests.Session()
         self._closed = False
 
@@ -29,7 +32,11 @@ class APIClient:
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=4, max=10))
     @circuit(failure_threshold=5, recovery_timeout=30)
     def analyze_file(
-        self, file_path: str, prompt: str, adaptive_timeouts: Dict[str, int] = None
+        self,
+        file_path: str,
+        prompt: str,
+        adaptive_timeouts: Optional[Dict[str, int]] = None,
+        stop_event: Optional[threading.Event] = None,
     ) -> Dict[str, Any]:
         """Analyse un fichier avec timeouts adaptatifs."""
         if adaptive_timeouts:
@@ -39,10 +46,12 @@ class APIClient:
             timeout = self.base_timeout
             http_timeout = self.base_http_timeout
 
-        logger.info("Upload %s (timeout: %ds)", file_path, timeout)
+        logger.info("Upload %s (timeout: %ds, http: %ds)", file_path, timeout, http_timeout)
         task_id = self._upload_file(file_path, prompt, http_timeout)
         logger.debug("Task id obtenu: %s", task_id)
-        result = self._poll_result(task_id, timeout=timeout, http_timeout=http_timeout)
+        result = self._poll_result(
+            task_id, timeout=timeout, http_timeout=http_timeout, stop_event=stop_event
+        )
         result["task_id"] = task_id
         return result
 
@@ -61,22 +70,43 @@ class APIClient:
         payload = resp.json()
         return payload.get("task_id")
 
-    def _poll_result(self, task_id: str, timeout: int = 300, http_timeout: int = 30) -> Dict[str, Any]:
+    def _poll_result(
+        self,
+        task_id: str,
+        timeout: int = 300,
+        http_timeout: int = 30,
+        stop_event: Optional[threading.Event] = None,
+    ) -> Dict[str, Any]:
         start = time.time()
         while True:
+            if stop_event and stop_event.is_set():
+                logger.info("Polling interrupted for task %s", task_id)
+                return {"status": "cancelled", "error": "interrupted_by_user"}
+
             if time.time() - start > timeout:
                 return {"status": "failed", "error": "timeout"}
-            resp = self.session.get(
-                f"{self.url}/api/v2/status/{task_id}",
-                headers=self._headers(),
-                timeout=http_timeout,
-            )
-            resp.raise_for_status()
-            payload = resp.json()
+
+            try:
+                resp = self.session.get(
+                    f"{self.url}/api/v2/status/{task_id}",
+                    headers=self._headers(),
+                    timeout=http_timeout,
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+            except requests.exceptions.Timeout:
+                logger.warning("HTTP timeout (%ds) polling task %s", http_timeout, task_id)
+                time.sleep(5)
+                continue
+
             status = payload.get("status")
             if status in {"completed", "failed"}:
                 return payload
-            time.sleep(2)
+
+            for _ in range(20):
+                if stop_event and stop_event.is_set():
+                    return {"status": "cancelled", "error": "interrupted_during_sleep"}
+                time.sleep(0.1)
 
     def health_check(self) -> bool:
         try:


### PR DESCRIPTION
## Summary
- add stop_event support in APIClient polling
- propagate stop_event through ContentAnalyzer and multi-worker thread
- expose HTTP timeout configuration in YAML
- adapt AdaptivePipelineManager to use configured timeouts
- enhance worker loop to respond promptly to stop requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68683d02aafc8320a38d062d1a749b95