### PR TITLE
Fix API Test reliability analysis and add tests

### DIFF
--- a/content_analyzer/tests/test_api_test_thread.py
+++ b/content_analyzer/tests/test_api_test_thread.py
@@ -35,3 +35,36 @@ def test_export_csv(tmp_path):
     export = thread.export_test_results("csv")
     assert export.exists()
     assert export.stat().st_size > 0
+
+
+def test_analyze_llm_reliability_with_none_results(tmp_path):
+    thread = APITestThread(CFG, tmp_path / "f.txt", 1, 1, 0, "comprehensive")
+
+    test_results = [
+        None,
+        {"status": "error", "result": None},
+        {"status": "completed", "result": {}},
+        {"status": "completed", "result": {"security": {"classification": "safe"}}},
+    ]
+
+    analysis = thread.analyze_llm_reliability(test_results)
+
+    assert analysis["valid_responses"] >= 1
+    assert isinstance(analysis.get("security_variance", 0), (int, float))
+
+
+def test_analyze_llm_reliability_empty_results(tmp_path):
+    thread = APITestThread(CFG, tmp_path / "f.txt", 1, 1, 0, "comprehensive")
+
+    analysis = thread.analyze_llm_reliability([])
+
+    assert analysis["valid_responses"] == 0
+    assert analysis["failed_responses"] == 0
+
+
+def test_analyze_response_variance_with_none(tmp_path):
+    thread = APITestThread(CFG, tmp_path / "f.txt", 1, 1, 0, "comprehensive")
+
+    thread._analyze_response_variance(None)
+    thread._analyze_response_variance({})
+    thread._analyze_response_variance({"security": None})


### PR DESCRIPTION
## Summary
- improve `_analyze_response_variance` to guard against None
- add `_is_valid_response` helper and use it in `analyze_llm_reliability`
- compute reliability metrics only on valid responses
- add helpers for variance, consistency and reliability score
- harden `get_summary_report` with error handling
- add unit tests covering None results in reliability analysis

## Testing
- `pytest content_analyzer/tests/test_api_test_thread.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869013710548320b2fb62a11d6bb01d