### PR TITLE
Fix cache, threading, DB indexes

### DIFF
--- a/content_analyzer/content_analyzer.py
+++ b/content_analyzer/content_analyzer.py
@@ -33,8 +33,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Lock global pour parsing JSON thread-safe
-_json_parsing_lock = threading.Lock()
 
 
 class ContentAnalyzer:
@@ -168,9 +166,8 @@ class ContentAnalyzer:
     def _thread_safe_parse_api_response(
         self, api_result: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Parse la réponse API de manière thread-safe."""
-        with _json_parsing_lock:
-            return self._parse_api_response(api_result)
+        """Parse la réponse API."""
+        return self._parse_api_response(api_result)
 
     def _extract_json_from_content(self, content: str) -> Optional[Dict[str, Any]]:
         import json

--- a/content_analyzer/modules/sql_optimizer.py
+++ b/content_analyzer/modules/sql_optimizer.py
@@ -62,20 +62,27 @@ class SQLQueryOptimizer:
                 offset += chunk_size
 
     # ------------------------------------------------------------------
-    def create_specialized_indexes(self, conn: sqlite3.Connection) -> None:
-        """Crée les indexes composites utilisés pour la GUI."""
-        specialized_indexes = [
-            "CREATE INDEX IF NOT EXISTS idx_gui_analytics_composite ON fichiers(status, file_size, last_modified, fast_hash, extension)",
-            "CREATE INDEX IF NOT EXISTS idx_duplicate_detection_enhanced ON fichiers(fast_hash, file_size) WHERE fast_hash IS NOT NULL",
-            "CREATE INDEX IF NOT EXISTS idx_age_analysis ON fichiers(last_modified, creation_time) WHERE status='completed'",
-            "CREATE INDEX IF NOT EXISTS idx_size_analysis ON fichiers(file_size, extension) WHERE file_size > 0",
+    @staticmethod
+    def get_specialized_index_definitions() -> List[Tuple[str, str]]:
+        """Return SQL definitions for specialized indexes."""
+        return [
+            (
+                "CREATE INDEX IF NOT EXISTS idx_gui_analytics_composite ON fichiers(status, file_size, last_modified, fast_hash, extension)",
+                "idx_gui_analytics_composite",
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_duplicate_detection_enhanced ON fichiers(fast_hash, file_size) WHERE fast_hash IS NOT NULL",
+                "idx_duplicate_detection_enhanced",
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_age_analysis ON fichiers(last_modified, creation_time) WHERE status='completed'",
+                "idx_age_analysis",
+            ),
+            (
+                "CREATE INDEX IF NOT EXISTS idx_size_analysis ON fichiers(file_size, extension) WHERE file_size > 0",
+                "idx_size_analysis",
+            ),
         ]
-        for sql in specialized_indexes:
-            try:
-                conn.execute(sql)
-            except sqlite3.OperationalError:
-                # Ignore errors to keep backward compatibility
-                pass
 
     # ------------------------------------------------------------------
     def execute_chunked_query(

--- a/content_analyzer/tests/test_regressions.py
+++ b/content_analyzer/tests/test_regressions.py
@@ -1,0 +1,97 @@
+import threading
+import time
+import tkinter as tk
+from pathlib import Path
+import pytest
+import warnings
+warnings.filterwarnings("ignore", category=pytest.PytestUnraisableExceptionWarning)
+
+from content_analyzer.content_analyzer import ContentAnalyzer
+from content_analyzer.modules.db_manager import DBManager
+from gui.analytics_panel import AnalyticsPanel
+
+
+def test_cache_metrics_fix(monkeypatch):
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        return
+    panel = AnalyticsPanel(root)
+    # patch calculation core to avoid DB
+    def fake_core():
+        return {"global": {"total_files": 1, "total_size_gb": 1}}
+    monkeypatch.setattr(panel, "_calculate_metrics_core", fake_core)
+
+    panel.threshold_age_years.set("1")
+    metrics_a = panel.calculate_business_metrics()
+    panel.threshold_age_years.set("2")
+    metrics_b = panel.calculate_business_metrics()
+    panel.threshold_age_years.set("1")
+    start = time.time()
+    metrics_a2 = panel.calculate_business_metrics()
+    elapsed = time.time() - start
+    root.destroy()
+    panel.db_manager = None
+    assert elapsed < 0.1
+    assert len(panel._metrics_cache) >= 2
+    assert metrics_a == metrics_a2
+
+
+def test_async_calculations(monkeypatch):
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        return
+    panel = AnalyticsPanel(root)
+    def fake_core():
+        time.sleep(0.2)
+        return {"global": {"total_files": 1, "total_size_gb": 1}}
+    monkeypatch.setattr(panel, "_calculate_metrics_core", fake_core)
+    panel.update_alert_cards()
+    assert panel._calculation_in_progress
+    while panel._calculation_in_progress:
+        root.update()
+        time.sleep(0.05)
+    root.destroy()
+    panel.db_manager = None
+    assert "✅" in panel.progress_label.cget("text")
+
+
+def test_concurrent_json_parsing():
+    analyzer = ContentAnalyzer()
+    api_res = {"status": "completed", "result": {"content": "{}"}, "task_id": "1"}
+    def worker():
+        return analyzer._thread_safe_parse_api_response(api_res)
+    results = []
+    threads = [threading.Thread(target=lambda: results.append(worker())) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(results) == 20
+    assert all(r["status"] == "completed" for r in results)
+    analyzer.close()
+
+
+def test_index_consolidation(tmp_path):
+    db_file = tmp_path / "test.db"
+    with DBManager(db_file) as db:
+        with db._connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS fichiers ("
+                "id INTEGER PRIMARY KEY,"
+                "status TEXT,"
+                "priority_score INTEGER,"
+                "fast_hash TEXT,"
+                "file_size INTEGER,"
+                "last_modified TEXT,"
+                "creation_time TEXT,"
+                "extension TEXT,"
+                "owner TEXT"
+                ")"
+            )
+            db._ensure_indexes_with_validation(conn)
+        report = db.verify_index_health()
+        assert report["health_status"] == "OK"


### PR DESCRIPTION
## Summary
- keep analytics cache entries per key
- add async calculations for analytics metrics
- remove unnecessary JSON parsing lock
- centralize SQLite index creation and add health check
- use SQLiteConnectionManager in GUI database methods
- add regression tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686be87bbfc48320918e139b0d3ace2e