### PR TITLE
Fix date parsing in AgeAnalyzer

### DIFF
--- a/content_analyzer/modules/age_analyzer.py
+++ b/content_analyzer/modules/age_analyzer.py
@@ -13,13 +13,35 @@ class AgeAnalyzer:
     """Perform analysis on file ages."""
 
     def _parse_time(self, value: str) -> datetime:
+        """Parse a string into a ``datetime`` object.
+
+        Returns ``datetime.max`` when the value cannot be parsed. The accepted
+        formats mirror those used in :class:`AnalyticsPanel` so that both parts
+        of the application interpret dates consistently.
+        """
+
         if not value:
             return datetime.max
-        for fmt in ("%d/%m/%Y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+
+        formats = [
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M:%S.%f",
+            "%Y-%m-%d",
+            "%d/%m/%Y %H:%M:%S",
+            "%d/%m/%Y",
+        ]
+
+        for fmt in formats:
             try:
                 return datetime.strptime(value.strip(), fmt)
             except ValueError:
                 continue
+
+        try:
+            return datetime.fromtimestamp(float(value))
+        except (ValueError, TypeError):
+            pass
+
         logger.warning("Could not parse date: %s", value)
         return datetime.max
 

--- a/content_analyzer/tests/test_age_analyzer.py
+++ b/content_analyzer/tests/test_age_analyzer.py
@@ -44,3 +44,19 @@ def test_age_statistics():
     stats = analyzer.get_age_statistics(files)
     assert stats["max_days"] >= 2
     assert stats["min_days"] >= 1
+
+
+def test_parse_time_additional_formats():
+    analyzer = AgeAnalyzer()
+
+    dt_str_micro = "2024-03-01 12:34:56.123456"
+    dt_micro = analyzer._parse_time(dt_str_micro)
+    assert dt_micro == datetime(2024, 3, 1, 12, 34, 56, 123456)
+
+    dt_str_short = "01/03/2024"
+    dt_short = analyzer._parse_time(dt_str_short)
+    assert dt_short == datetime(2024, 3, 1)
+
+    timestamp = datetime(2024, 3, 1, 12, 0, 0).timestamp()
+    dt_ts = analyzer._parse_time(str(timestamp))
+    assert dt_ts == datetime.fromtimestamp(timestamp)


### PR DESCRIPTION
## Summary
- extend `_parse_time` in `AgeAnalyzer` with the same formats as `AnalyticsPanel`
- add fallback for timestamps
- test new date parsing capabilities

## Testing
- `pytest content_analyzer/tests/test_age_analyzer.py::test_parse_time_additional_formats -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c2b19dbc832098f58895b680aa1c